### PR TITLE
Add ability to schedule jobs at runtime and ability to view jobs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,9 +14,9 @@ defmodule Quantum.Mixfile do
     ]
   end
 
-  def application,        do: application(Mix.env)
-  def application(:test), do: [applications: []]
-  def application(_),     do: [applications: [], mod: {Quantum.Application, []}]
+  def application do
+    [applications: [], mod: {Quantum.Application, []}]
+  end
 
   defp package do
     %{

--- a/test/quantum_test.exs
+++ b/test/quantum_test.exs
@@ -29,5 +29,12 @@ defmodule QuantumTest do
   test "daily" do
     Quantum.execute(:"@DAILY", fn -> IO.puts("FAIL") end, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1})
   end
+
+  test "adding a job at run time" do
+    spec = "1 * * * *"
+    job = fn -> :ok end
+    :ok = Quantum.add_job(spec, job)
+    assert [{spec, job}] == Quantum.jobs
+  end
   
 end


### PR DESCRIPTION
Re: #1 

My use case for this is that anonymous functions in the config file are incompatible with my deployment procedure, and, unless I'm wrong, anyone else using exrm.