### PR TITLE
Some adaption for conform/exrm

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Configure your cronjobs in your `config/config.exs` like this:
 ```elixir
 config :quantum, cron: [
     # Every minute
-    "* * * * *":      &Heartbeat.send/0,
+    "* * * * *":      {"Heartbeat", :send},
     # Every 15 minutes
     "*/15 * * * *":   fn -> System.cmd("rm", ["/tmp/tmp_"] end,
     # Runs on 18, 20, 22, 0, 2, 4, 6:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ config :quantum, cron: [
 ]
 ```
 
+Or you can use cron-like format (useful with conform/exrm):
+```elixir
+config :quantum, cron: [
+    # Every minute
+    "* * * * * MyApp.MyModule.my_method"
+]
+```
+
 If you want to add jobs on runtime, this is possible, too:
 
 ```elixir

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -4,21 +4,21 @@ defmodule Quantum.Executor do
 
   import Quantum.Matcher
 
-  def execute({"@reboot",   fun}, %{r: 1}), do: fun.()
+  def execute({"@reboot",   fun}, %{r: 1}), do: execute_fun(fun)
   def execute(_,                  %{r: 1}), do: false
-  def execute({"* * * * *", fun}, _), do: fun.()
-  def execute({"@hourly",   fun}, %{m: 0}), do: fun.()
-  def execute({"0 * * * *", fun}, %{m: 0}), do: fun.()
-  def execute({"@daily",    fun}, %{m: 0, h: 0}), do: fun.()
-  def execute({"@midnight", fun}, %{m: 0, h: 0}), do: fun.()
-  def execute({"0 0 * * *", fun}, %{m: 0, h: 0}), do: fun.()
-  def execute({"@weekly",   fun}, %{m: 0, h: 0, w: 0}), do: fun.()
-  def execute({"0 0 * * 0", fun}, %{m: 0, h: 0, w: 0}), do: fun.()
-  def execute({"@monthly",  fun}, %{m: 0, h: 0, d: {_, _, 1}}), do: fun.()
-  def execute({"0 0 1 * *", fun}, %{m: 0, h: 0, d: {_, _, 1}}), do: fun.()
-  def execute({"@annually", fun}, %{m: 0, h: 0, d: {_, 1, 1}}), do: fun.()
-  def execute({"@yearly",   fun}, %{m: 0, h: 0, d: {_, 1, 1}}), do: fun.()
-  def execute({"0 0 1 1 *", fun}, %{m: 0, h: 0, d: {_, 1, 1}}), do: fun.()
+  def execute({"* * * * *", fun}, _), do: execute_fun(fun)
+  def execute({"@hourly",   fun}, %{m: 0}), do: execute_fun(fun)
+  def execute({"0 * * * *", fun}, %{m: 0}), do: execute_fun(fun)
+  def execute({"@daily",    fun}, %{m: 0, h: 0}), do: execute_fun(fun)
+  def execute({"@midnight", fun}, %{m: 0, h: 0}), do: execute_fun(fun)
+  def execute({"0 0 * * *", fun}, %{m: 0, h: 0}), do: execute_fun(fun)
+  def execute({"@weekly",   fun}, %{m: 0, h: 0, w: 0}), do: execute_fun(fun)
+  def execute({"0 0 * * 0", fun}, %{m: 0, h: 0, w: 0}), do: execute_fun(fun)
+  def execute({"@monthly",  fun}, %{m: 0, h: 0, d: {_, _, 1}}), do: execute_fun(fun)
+  def execute({"0 0 1 * *", fun}, %{m: 0, h: 0, d: {_, _, 1}}), do: execute_fun(fun)
+  def execute({"@annually", fun}, %{m: 0, h: 0, d: {_, 1, 1}}), do: execute_fun(fun)
+  def execute({"@yearly",   fun}, %{m: 0, h: 0, d: {_, 1, 1}}), do: execute_fun(fun)
+  def execute({"0 0 1 1 *", fun}, %{m: 0, h: 0, d: {_, 1, 1}}), do: execute_fun(fun)
   def execute({"@hourly",   _}, _), do: false
   def execute({"@daily",    _}, _), do: false
   def execute({"@midnight", _}, _), do: false
@@ -35,8 +35,13 @@ defmodule Quantum.Executor do
       !match(d, cur_day, 1, 31) -> false
       !match(n, cur_mon, 1, 12) -> false
       !match(w, state.w, 0,  6) -> false
-      true                      -> fun.()
+      true                      -> execute_fun(fun)
     end
   end
 
+  defp execute_fun({module, method}) do
+    :erlang.apply(String.to_atom("Elixir.#{module}"), method, [])
+  end
+
+  defp execute_fun(fun), do: fun.()
 end

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -40,7 +40,11 @@ defmodule Quantum.Executor do
   end
 
   defp execute_fun({module, method}) do
-    :erlang.apply(String.to_atom("Elixir.#{module}"), method, [])
+    if is_binary(module) do
+      :erlang.apply(String.to_atom("Elixir.#{module}"), method, [])
+    else
+      :erlang.apply(module, method, [])
+    end
   end
 
   defp execute_fun(fun), do: fun.()

--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -6,7 +6,16 @@ defmodule Quantum.Normalizer do
   # Cron expression is converted to lowercase string and
   # day and month names are translated to their indexes.
   def normalize({e, fun}), do: {do_normalize(e), fun}
-  
+
+  # Converts a string representation of schedule+job into
+  # its canonical format.
+  # Ex.: * * * * * MyApp.MyModule.my_method
+  # into: {"* * * * *", {MyApp.MyModule, :my_method}}
+  def normalize(e) do
+  	[[_, schedule, module, method]] = Regex.scan(~r/^(\S+\s+\S+\s+\S+\s+\S+\s+\S+)\s+(.*)\.(\w+)$/, e)
+  	{do_normalize(schedule), {module, String.to_atom(method)}}
+  end
+
   defp do_normalize(e) when e |> is_atom, do: do_normalize e |> Atom.to_string
   defp do_normalize(e), do: e |> String.downcase |> Quantum.Translator.translate
 

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -3,7 +3,7 @@ defmodule Quantum.ExecutorTest do
 
   import Quantum.Executor
 
-  defp ok, do: :ok
+  def ok, do: :ok
 
   test "check minutely" do
     assert execute({"* * * * *", &ok/0}, %{}) == :ok
@@ -55,9 +55,13 @@ defmodule Quantum.ExecutorTest do
   test "parse 5" do
     assert execute({"5 * * * *",  &ok/0}, %{d: {2015, 12, 31}, h: 12, m: 5, w: 1}) == :ok
   end
-  
+
   test "counter example" do
     execute({"5 * * * *", &flunk/0}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1})
+  end
+
+  test "function as tuple" do
+    assert execute({"* * * * *", {__MODULE__, :ok}}, %{}) == :ok
   end
 
 end

--- a/test/normalizer_test.exs
+++ b/test/normalizer_test.exs
@@ -8,6 +8,7 @@ defmodule Quantum.NormalizerTest do
     assert normalize({"A", nil}) == {"a", nil}
     assert normalize({"jan", nil}) == {"1", nil}
     assert normalize({:atom, nil}) == {"atom", nil}
+    assert normalize("* * * * * MyApp.MyModule.my_method") == {"* * * * *", {"MyApp.MyModule", :my_method}}
   end
 
 end


### PR DESCRIPTION
@c-rack thanks for quantum first of all :)

I've got some troubles using quantum with exrm.
First I need to generate some configs like this:

```
$ mix conform.new
$ mix conform.configure
```

and after

```
$ mix conform.effective
```

it fails. Looks like it can't convert quantum's config into his own of release. I've tried many variants and decided to use simple form of configuration, just like in cron:

```
* * * * * MyApp.MyModule.my_method
```
Configuration looks like:
```
config :quantum, cron: [
    "* * * * * MyApp.MyModule.my_method"
]
```
Hope this will be useful for others.