### PR TITLE
Solution: rename "contributors" to "maintainers" in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Quantum.Mixfile do
 
   defp package do
     %{
-      contributors: [
+      maintainers: [
         "Constantin Rack",
         "Dan Swain",
         "Lenz Gschwendtner",


### PR DESCRIPTION
See this commit for further details:
https://github.com/hexpm/hex/commit/3dd315b2567cdb94f37747bf8dd8a63eda1bca0b