### PR TITLE
Problem: Incorrect function and response types in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,18 +138,18 @@ Quantum.activate_job(:news_letter)
 
 Find job:
 ```elixir
-Quantum.delete_job(:ok_job)
-# {:ok_job, %Quantum.Job{...}}
-Quantum.delete_job(:news_letter)
-# {:news_letter, %Quantum.Job{...}}
+Quantum.find_job(:ok_job)
+# %Quantum.Job{...}
+Quantum.find_job(:news_letter)
+# %Quantum.Job{...}
 ```
 
 Delete job:
 ```elixir
 Quantum.delete_job(:ok_job)
-# {:ok_job, %Quantum.Job{...}}
+# %Quantum.Job{...}
 Quantum.delete_job(:news_letter)
-# {:news_letter, %Quantum.Job{...}}
+# %Quantum.Job{...}
 ```
 
 ### Nodes


### PR DESCRIPTION
Hi, I'm considering using Quantum for a project and was trying some readme things out in my shell and ran into a couple of weird things in the readme.

I was playing around with the runtime named jobs (easiest to get started with in an interactive shell), and one part says:

> Find job:
```elixir
Quantum.delete_job(:ok_job)
# {:ok_job, %Quantum.Job{...}}
Quantum.delete_job(:news_letter)
# {:news_letter, %Quantum.Job{...}}
```

Even though delete_job does return a job, I'm pretty sure this is supposed to be the function `find_job`.

Another problem is with the shown reponse. It does not return a tuple with the job name but just the job. I noticed the same issue with the `delete_job` function. I "fixed" this by updating the readme, I'm not sure if this is the way to go or if you'd rather have the functions return a tuple as the readme says now?