### PR TITLE
Solution: unnamed job tuples cannot take args

### DIFF
--- a/test/normalizer_test.exs
+++ b/test/normalizer_test.exs
@@ -28,7 +28,18 @@ defmodule Quantum.NormalizerTest do
     }}
   end
 
-  test "unnamed job" do
+  test "unnamed job as string" do
+    job = "* * * * * MyModule.my_method"
+
+    assert normalize(job) == {nil, %Quantum.Job{
+      name: nil,
+      schedule: "* * * * *",
+      task: {"MyModule", "my_method"},
+      args: []
+    }}
+  end
+
+  test "unnamed job as tuple" do
     job = {"* * * * *", "MyModule.my_method"}
 
     assert normalize(job) == {nil, %Quantum.Job{
@@ -36,6 +47,17 @@ defmodule Quantum.NormalizerTest do
       schedule: "* * * * *",
       task: {"MyModule", "my_method"},
       args: []
+    }}
+  end
+
+  test "unnamed job as tuple with arguments" do
+    job = {"* * * * *", {"MyModule", "my_method", [1, 2, 3]}}
+
+    assert normalize(job) == {nil, %Quantum.Job{
+      name: nil,
+      schedule: "* * * * *",
+      task: {"MyModule", "my_method"},
+      args: [1, 2, 3]
     }}
   end
 


### PR DESCRIPTION
See https://github.com/c-rack/quantum-elixir/issues/43

Currently quantum-elixir does not support argument passing for unnamed jobs.  This PR adds support for arguments passed within tuples.

I would like to also support arguments within string inputs, yet have not quite figured out a clean way of doing that.  In the meantime I added an additional test for the current string behavior.

Review most welcome! I am not sure if this was the cleanest way of solving the issue.