### PR TITLE
Solution: job names can be other types different to atoms

### DIFF
--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -41,7 +41,7 @@ defmodule Quantum do
   @doc "Resolves a job by name"
   @spec find_job(expr) :: job
   def find_job(name) do
-    Keyword.get(jobs, name)
+    find_by_name(jobs, name)
   end
 
   @doc "Deletes a job by name"
@@ -79,10 +79,10 @@ defmodule Quantum do
   end
 
   def handle_call({:delete, n}, _, s) do
-    job = case Keyword.get(s.jobs, n) do
+    job = case find_by_name(s.jobs, n) do
       nil -> nil
       job ->
-        s = %{s | jobs: Keyword.delete(s.jobs, n)}
+        s = %{s | jobs: List.keydelete(s.jobs, n, 0)}
         job
     end
     {:reply, job, s}
@@ -120,6 +120,13 @@ defmodule Quantum do
       job.pid == nil          -> true  # Job has not been started before
       Process.alive?(job.pid) -> false # Previous job is still running
       true                    -> true  # Previous job has finished
+    end
+  end
+
+  defp find_by_name(jobs, job_name) do
+    case List.keyfind(jobs, job_name, 0) do
+      nil          -> nil
+      {_name, job} -> job
     end
   end
 

--- a/test/quantum_test.exs
+++ b/test/quantum_test.exs
@@ -1,6 +1,8 @@
 defmodule QuantumTest do
   use ExUnit.Case
 
+  defp job_names, do: ["test_job", :test_job, 'test_job']
+
   test "adding a job at run time" do
     spec = "1 * * * *"
     fun = fn -> :ok end
@@ -10,24 +12,26 @@ defmodule QuantumTest do
   end
 
   test "adding a named job as options at run time" do
-    name = "test_job"
-    spec = "1 * * * *"
-    fun = fn -> :ok end
-    job_otps = %{schedule: spec, task: fun}
-    job = %Quantum.Job{} |> Map.merge(job_otps)
-    :ok = Quantum.add_job(name, job_otps)
-    assert Enum.member? Quantum.jobs, {name, %{job | name: name,
-                                                     nodes: [node()]}}
+    for name <- job_names do
+      spec = "1 * * * *"
+      fun = fn -> :ok end
+      job_otps = %{schedule: spec, task: fun}
+      job = %Quantum.Job{} |> Map.merge(job_otps)
+      :ok = Quantum.add_job(name, job_otps)
+      assert Enum.member? Quantum.jobs, {name, %{job | name: name,
+                                                       nodes: [node()]}}
+    end
   end
 
   test "adding a named job struct at run time" do
-    name = "test_job"
-    spec = "1 * * * *"
-    fun = fn -> :ok end
-    job = %Quantum.Job{schedule: spec, task: fun}
-    :ok = Quantum.add_job(name, job)
-    assert Enum.member? Quantum.jobs, {name, %{job | name: name,
-                                                     nodes: [node()]}}
+    for name <- job_names do
+      spec = "1 * * * *"
+      fun = fn -> :ok end
+      job = %Quantum.Job{schedule: spec, task: fun}
+      :ok = Quantum.add_job(name, job)
+      assert Enum.member? Quantum.jobs, {name, %{job | name: name,
+                                                       nodes: [node()]}}
+    end
   end
 
   test "adding a unnamed job at run time" do
@@ -55,50 +59,54 @@ defmodule QuantumTest do
   end
 
   test "finding a named job" do
-    name = :newsletter
-    spec = "* * * * *"
-    fun = fn -> :ok end
-    job = %Quantum.Job{schedule: spec, task: fun}
-    :ok = Quantum.add_job(name, job)
-    fjob = Quantum.find_job(name)
-    assert fjob.name == name
-    assert fjob.schedule == spec
-    assert fjob.nodes == [node()]
+    for name <- job_names do
+      spec = "* * * * *"
+      fun = fn -> :ok end
+      job = %Quantum.Job{schedule: spec, task: fun}
+      :ok = Quantum.add_job(name, job)
+      fjob = Quantum.find_job(name)
+      assert fjob.name == name
+      assert fjob.schedule == spec
+      assert fjob.nodes == [node()]
+    end
   end
 
   test "deactivating a named job" do
-    name = :newsletter
-    spec = "* * * * *"
-    fun = fn -> :ok end
-    job = %Quantum.Job{name: name, schedule: spec, task: fun}
-    :ok = Quantum.add_job(name, job)
-    :ok = Quantum.deactivate_job(name)
-    sjob = Quantum.find_job(name)
-    assert sjob == %{job | state: :inactive}
+    for name <- job_names do
+      spec = "* * * * *"
+      fun = fn -> :ok end
+      job = %Quantum.Job{name: name, schedule: spec, task: fun}
+      :ok = Quantum.add_job(name, job)
+      :ok = Quantum.deactivate_job(name)
+      sjob = Quantum.find_job(name)
+      assert sjob == %{job | state: :inactive}
+    end
   end
 
   test "activating a named job" do
-    name = :newsletter
-    spec = "* * * * *"
-    fun = fn -> :ok end
-    job = %Quantum.Job{name: name, schedule: spec, task: fun, state: :inactive}
+    for name <- job_names do
+      spec = "* * * * *"
+      fun = fn -> :ok end
+      job = %Quantum.Job{name: name, schedule: spec, task: fun, state: :inactive}
 
-    :ok = Quantum.add_job(name, job)
-    :ok = Quantum.activate_job(name)
-    ajob = Quantum.find_job(name)
-    assert ajob == %{job | state: :active}
+      :ok = Quantum.add_job(name, job)
+      :ok = Quantum.activate_job(name)
+      ajob = Quantum.find_job(name)
+      assert ajob == %{job | state: :active}
+    end
   end
 
   test "deleting a named job at run time" do
-    spec = "* * * * *"
-    name = :newsletter
-    fun = fn -> :ok end
-    job = %Quantum.Job{name: name, schedule: spec, task: fun}
-    :ok = Quantum.add_job(name, job)
-    djob = Quantum.delete_job(name)
-    assert djob.name == name
-    assert djob.schedule == spec
-    assert !Enum.member? Quantum.jobs, {name, job}
+    for name <- job_names do
+      spec = "* * * * *"
+      fun = fn -> :ok end
+      job = %Quantum.Job{name: name, schedule: spec, task: fun}
+      :ok = Quantum.add_job(name, job)
+      djob = Quantum.delete_job(name)
+      assert djob.name == name
+      assert djob.schedule == spec
+      assert !Enum.member? Quantum.jobs, {name, job}
+    end
   end
 
   test "handle_info" do


### PR DESCRIPTION
See #49 

Enable job names to be other types different to atoms. Any type that can be compared with === can be used as a job name.

Tests have been changed to use strings, atoms and charlists as job names.