### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /_build
 /deps
+/doc
 erl_crash.dump
 mix.lock
 *.ez

--- a/mix.exs
+++ b/mix.exs
@@ -8,11 +8,11 @@ defmodule Quantum.Mixfile do
       app: :quantum,
       build_embedded: Mix.env == :prod,
       deps: [
-        {:credo,       "~> 0.1.9", only: [:dev, :test]},
-        {:earmark,     "~> 0.1",   only: [:dev, :docs]},
-        {:ex_doc,      "~> 0.10",  only: [:dev, :docs]},
-        {:excoveralls, "~> 0.4",   only: [:dev, :test]},
-        {:inch_ex,     "~> 0.4",   only: [:dev, :docs]}
+        {:credo,       "~> 0.1",  only: [:dev, :test]},
+        {:earmark,     "~> 0.1",  only: [:dev, :docs]},
+        {:ex_doc,      "~> 0.10", only: [:dev, :docs]},
+        {:excoveralls, "~> 0.4",  only: [:dev, :test]},
+        {:inch_ex,     "~> 0.4",  only: [:dev, :docs]}
       ],
       description: "Cron-like job scheduler for Elixir.",
       docs: [


### PR DESCRIPTION
to use only `<major.minor>`.

This may avoid too frequent dependency-update-commits in the future.