### PR TITLE
Issue 76

### DIFF
--- a/lib/quantum/application.ex
+++ b/lib/quantum/application.ex
@@ -3,13 +3,27 @@ defmodule Quantum.Application do
   @moduledoc false
 
   import Quantum.Normalizer
+  require Logger
 
   use Application
 
   def start(_type, _args) do
-    jobs = :quantum |> Application.get_env(:cron, []) |> Enum.map(&normalize/1)
+    jobs = :quantum |> Application.get_env(:cron, [])
+    |> Enum.map(&normalize/1)
+    |> remove_jobs_with_duplicate_names
     state = %{jobs: jobs, d: nil, h: nil, m: nil, w: nil, r: nil}
     Quantum.Supervisor.start_link(state)
+  end
+
+  def remove_jobs_with_duplicate_names(job_list) do
+    Enum.reduce(job_list, [], fn({name, job}, acc) ->
+      if name && Enum.member?(Keyword.keys(acc), name) do
+        Logger.warn("A Quantum-job with the name \"#{name}\" has not been started because this job-name already exists.")
+        acc
+      else
+        [{name, job} | acc]
+      end
+    end)
   end
 
 end

--- a/test/quantum_startup_test.exs
+++ b/test/quantum_startup_test.exs
@@ -1,0 +1,21 @@
+defmodule QuantumStartupTest do
+  use ExUnit.Case
+
+  @tag :startup
+  test "prevent duplicate job names on startup" do
+    test_jobs =
+      [test_job: [schedule: "1 * * * *", task: fn -> :ok end],
+       test_job: [schedule: "2 * * * *", task: fn -> :ok end],
+       "3 * * * *": fn -> :ok end,
+       "4 * * * *": fn -> :ok end]
+
+    Application.stop(:quantum)
+    Application.put_env(:quantum, :cron, test_jobs)
+    Application.ensure_started(:logger)
+    Application.ensure_all_started(:quantum)
+    
+    assert Enum.count(Quantum.jobs) == 3
+    assert Quantum.find_job(:test_job).schedule == "1 * * * *"
+  end
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(exclude: [:startup])


### PR DESCRIPTION
Hi Constantin, please review my solution for the issue 76.

I made these changes:
- Check for existing names before adding a new job in function "add_job" of the GenServer. When a job-name already exists, the function returns :error instead of :ok.
- Remove duplicate names from the config-list before starting the application. In case of duplicate job-names, the app logs a warning-message.
- To write the tests, I introduced a GenServer-function "delete_all", which is used to clear the job-list in each test-case.
- The startup-behavior is tested in the new file "quantum_startup_test.exs", which stops and restarts the application. I tagged the testcase and excluded it by default.


 