### PR TITLE
Solution: do not crash Quantum GenServer when child job process crashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
 language: elixir
 sudo: false
 elixir:
-  - 1.0.4
-  - 1.0.5
-  - 1.1.0
   - 1.2.0
+  - 1.2.1
+  - 1.2.2
+  - 1.2.3
 otp_release:
-  - 17.4
-  - 17.5
   - 18.0
   - 18.1
+  - 18.2
 after_success:
   - "mix compile && mix coveralls.travis"
 after_script:
   - MIX_ENV=docs mix deps.get
   - MIX_ENV=docs mix inch.report
-

--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -131,7 +131,7 @@ defmodule Quantum do
   defp run(s) do
     Enum.map s.jobs, fn({name, j}) ->
       if j.state == :active && node() in j.nodes && check_overlap(j) do
-        t = Task.Supervisor.async(:quantum_tasks_sup, Quantum.Executor,
+        t = Task.Supervisor.async_nolink(:quantum_tasks_sup, Quantum.Executor,
                                   :execute, [{j.schedule, j.task, j.args}, s])
         {name, %{j | pid: t.pid}}
       else

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Quantum.Mixfile do
         source_ref: "v#{@version}",
         source_url: "https://github.com/c-rack/quantum-elixir"
       ],
-      elixir: ">= 1.0.0",
+      elixir: ">= 1.2.0",
       name: "Quantum",
       package: package,
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
See #82 

Use the `Task.Supervisor.async_nolink` introduced in Elixir 1.2.0 to spawn children jobs. This will avoid the crashing of the Quantum GenServer.