### PR TITLE
Solution: Adding optional per-job timezone support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Job struct:
   state: :active, # is used for internal purposes
   nodes: [:node@host], # default: [node()]
   overlap: false, # run even if previous job is still running?, default: true
-  pid: nil # PID of last executed task
+  pid: nil, # PID of last executed task
+  timezone: :local # Timezone to run task in, defaults to Quantum default (either :utc or :local)
 }
 ```
 

--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -132,7 +132,7 @@ defmodule Quantum do
     Enum.map s.jobs, fn({name, j}) ->
       if j.state == :active && node() in j.nodes && check_overlap(j) do
         t = Task.Supervisor.async_nolink(:quantum_tasks_sup, Quantum.Executor,
-                                  :execute, [{j.schedule, j.task, j.args}, s])
+                                  :execute, [{j.schedule, j.task, j.args, j.timezone}, s])
         {name, %{j | pid: t.pid}}
       else
         {name, j}

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -2,41 +2,79 @@ defmodule Quantum.Executor do
 
   @moduledoc false
 
+  alias Timex.Timezone
+  alias Timex.DateTime
   import Quantum.Matcher
 
-  def execute({"@reboot",   fun, args}, %{r: 1}), do: execute_fun(fun, args)
+  def convert_to_timezone(s, tz) do
+    t = {s.d, {s.h, s.m, 0}}  # Convert to erlang datetime
+    tz_final = case tz do
+      :utc   -> Timezone.get("UTC")
+      :local -> Timezone.local()
+      tz0    -> tz0
+    end
+
+    case Application.get_env(:quantum, :timezone, :utc) do
+      :utc   -> DateTime.from(t) |> Timezone.convert(tz_final)
+      :local -> DateTime.from(t, :local) |> Timezone.convert(tz_final)
+      tz     -> raise "Unsupported timezone: #{tz}"
+    end
+  end
+
+  def execute({"@reboot",   fun, args, tz}, %{r: 1}), do: execute_fun(fun, args)
   def execute(_,                        %{r: 1}), do: false
-  def execute({"@reboot",   _, _},      %{r: 0}), do: false
-  def execute({"* * * * *", fun, args}, _), do: execute_fun(fun, args)
-  def execute({"@hourly",   fun, args}, %{m: 0}), do: execute_fun(fun, args)
-  def execute({"0 * * * *", fun, args}, %{m: 0}), do: execute_fun(fun, args)
-  def execute({"@daily",    fun, args}, %{m: 0, h: 0}), do: execute_fun(fun, args)
-  def execute({"@midnight", fun, args}, %{m: 0, h: 0}), do: execute_fun(fun, args)
-  def execute({"0 0 * * *", fun, args}, %{m: 0, h: 0}), do: execute_fun(fun, args)
-  def execute({"@weekly",   fun, args}, %{m: 0, h: 0, w: 0}), do: execute_fun(fun, args)
-  def execute({"0 0 * * 0", fun, args}, %{m: 0, h: 0, w: 0}), do: execute_fun(fun, args)
-  def execute({"@monthly",  fun, args}, %{m: 0, h: 0, d: {_, _, 1}}), do: execute_fun(fun, args)
-  def execute({"0 0 1 * *", fun, args}, %{m: 0, h: 0, d: {_, _, 1}}), do: execute_fun(fun, args)
-  def execute({"@annually", fun, args}, %{m: 0, h: 0, d: {_, 1, 1}}), do: execute_fun(fun, args)
-  def execute({"@yearly",   fun, args}, %{m: 0, h: 0, d: {_, 1, 1}}), do: execute_fun(fun, args)
-  def execute({"0 0 1 1 *", fun, args}, %{m: 0, h: 0, d: {_, 1, 1}}), do: execute_fun(fun, args)
-  def execute({"@hourly",   _, _}, _), do: false
-  def execute({"@daily",    _, _}, _), do: false
-  def execute({"@midnight", _, _}, _), do: false
-  def execute({"@weekly",   _, _}, _), do: false
-  def execute({"@annually", _, _}, _), do: false
-  def execute({"@yearly",   _, _}, _), do: false
-  def execute({"@monthly",  _, _}, _), do: false
-  def execute({e, fun, args}, state) do
+  def execute({"@reboot",   _, _, _},   %{r: 0}), do: false
+  def execute({"* * * * *", fun, args, tz}, _), do: execute_fun(fun, args)
+
+  def execute({"@hourly", fun, args, tz}, state) do
+    c = convert_to_timezone(state, tz)
+    if c.minute == 0, do: execute_fun(fun, args), else: false
+  end
+
+  def execute({"@daily", fun, args, tz}, state) do
+    c = convert_to_timezone(state, tz)
+    if c.minute == 0 and c.hour == 0, do: execute_fun(fun, args), else: false
+  end
+
+  def execute({"@midnight", fun, args, tz}, state) do
+    c = convert_to_timezone(state, tz)
+    if c.minute == 0 and c.hour == 0, do: execute_fun(fun, args), else: false
+  end
+
+  def execute({"@weekly", fun, args, tz}, state) do
+    c = convert_to_timezone(state, tz)
+    c_weekday = rem(Timex.weekday(c), 7)
+    if c.minute == 0 and c.hour == 0 and c_weekday == 0, do: execute_fun(fun, args), else: false
+  end
+
+  def execute({"@monthly", fun, args, tz}, state) do
+    c = convert_to_timezone(state, tz)
+    if c.minute == 0 and c.hour == 0 and c.day == 1, do: execute_fun(fun, args), else: false
+  end
+
+  def execute({"@annually", fun, args, tz}, state) do
+    c = convert_to_timezone(state, tz)
+    if c.minute == 0 and c.hour == 0 and c.day == 1 and c.month == 1, do: execute_fun(fun, args), else: false
+  end
+
+  def execute({"@yearly", fun, args, tz}, state) do
+    c = convert_to_timezone(state, tz)
+    if c.minute == 0 and c.hour == 0 and c.day == 1 and c.month == 1, do: execute_fun(fun, args), else: false
+  end
+
+  def execute({e, fun, args, tz}, state) do
     [m, h, d, n, w] = e |> String.split(" ")
-    {_, cur_mon, cur_day} = state.d
+
+    c = convert_to_timezone(state, tz)
+    c_weekday = rem(Timex.weekday(c), 7)
+
     cond do
-      !match(m, state.m, 0..59) -> false
-      !match(h, state.h, 0..23) -> false
-      !match(d, cur_day, 1..31) -> false
-      !match(n, cur_mon, 1..12) -> false
-      !match(w, state.w, 0..6)  -> false
-      true                      -> execute_fun(fun, args)
+      !match(m, c.minute,  0..59) -> false
+      !match(h, c.hour,    0..23) -> false
+      !match(d, c.day,     1..31) -> false
+      !match(n, c.month,   1..12) -> false
+      !match(w, c_weekday, 0..6)  -> false
+      true                        -> execute_fun(fun, args)
     end
   end
 

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -6,6 +6,7 @@ defmodule Quantum.Job do
   @default_args     Application.get_env(:quantum, :default_args, [])
   @default_nodes    Application.get_env(:quantum, :default_nodes, [node()])
   @default_overlap  Application.get_env(:quantum, :default_overlap, true)
+  @default_timezone Application.get_env(:quantum, :timezone, :utc)
 
   defstruct [
     name: nil,
@@ -15,7 +16,8 @@ defmodule Quantum.Job do
     state: :active, # active/inactive
     nodes: @default_nodes,
     overlap: @default_overlap,
-    pid: nil
+    pid: nil,
+    timezone: @default_timezone
   ]
 
   @type t :: %Quantum.Job{}

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Quantum.Mixfile do
       app: :quantum,
       build_embedded: Mix.env == :prod,
       deps: [
+        {:timex,       "~> 2.1.1"},
         {:credo,       "~> 0.3",  only: [:dev, :test]},
         {:earmark,     "~> 0.2",  only: [:dev, :docs]},
         {:ex_doc,      "~> 0.11", only: [:dev, :docs]},
@@ -30,7 +31,7 @@ defmodule Quantum.Mixfile do
   end
 
   def application do
-    [applications: [], mod: {Quantum.Application, []}]
+    [applications: [:timex], mod: {Quantum.Application, []}]
   end
 
   defp package do

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -1,82 +1,84 @@
 defmodule Quantum.ExecutorTest do
   use ExUnit.Case
 
+  @default_timezone Application.get_env(:quantum, :timezone, :utc)
+
   import Quantum.Executor
 
   def ok,     do: :ok
   def ret(v), do: v
 
   test "check minutely" do
-    assert execute({"* * * * *", &ok/0, []}, %{}) == :ok
+    assert execute({"* * * * *", &ok/0, [], @default_timezone}, %{}) == :ok
   end
 
   test "check hourly" do
-    assert execute({"0 * * * *", &ok/0, []}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
-    assert execute({"0 * * * *", &ok/0, []}, %{d: {2015, 12, 31}, h: 12, m: 1, w: 1}) == false
-    assert execute({"@hourly",   &ok/0, []}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
-    assert execute({"@hourly",   &ok/0, []}, %{d: {2015, 12, 31}, h: 12, m: 1, w: 1}) == false
+    assert execute({"0 * * * *", &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
+    assert execute({"0 * * * *", &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, w: 1}) == false
+    assert execute({"@hourly",   &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
+    assert execute({"@hourly",   &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, w: 1}) == false
   end
 
   test "check daily" do
-    assert execute({"0 0 * * *", &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
-    assert execute({"0 0 * * *", &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
-    assert execute({"@daily",    &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
-    assert execute({"@daily",    &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
-    assert execute({"@midnight", &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
-    assert execute({"@midnight", &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
+    assert execute({"0 0 * * *", &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
+    assert execute({"0 0 * * *", &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
+    assert execute({"@daily",    &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
+    assert execute({"@daily",    &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
+    assert execute({"@midnight", &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
+    assert execute({"@midnight", &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
   end
 
   test "check weekly" do
-    assert execute({"0 0 * * 0", &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({"0 0 * * 0", &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 0}) == false
-    assert execute({"@weekly",   &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({"@weekly",   &ok/0, []}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 0}) == false
+    assert execute({"0 0 * * 0", &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({"0 0 * * 0", &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, w: 0}) == false
+    assert execute({"@weekly",   &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({"@weekly",   &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, w: 0}) == false
   end
 
   test "check monthly" do
-    assert execute({"0 0 1 * *", &ok/0, []}, %{d: {2015, 12, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({"0 0 1 * *", &ok/0, []}, %{d: {2015, 12, 1}, h: 0, m: 1, w: 0}) == false
-    assert execute({"@monthly",  &ok/0, []}, %{d: {2015, 12, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({"@monthly",  &ok/0, []}, %{d: {2015, 12, 1}, h: 0, m: 1, w: 0}) == false
+    assert execute({"0 0 1 * *", &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({"0 0 1 * *", &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, w: 0}) == false
+    assert execute({"@monthly",  &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({"@monthly",  &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, w: 0}) == false
   end
 
   test "check yearly" do
-    assert execute({"0 0 1 1 *", &ok/0, []}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({"0 0 1 1 *", &ok/0, []}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
-    assert execute({"@annually", &ok/0, []}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({"@annually", &ok/0, []}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
-    assert execute({"@yearly",   &ok/0, []}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({"@yearly",   &ok/0, []}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
+    assert execute({"0 0 1 1 *", &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({"0 0 1 1 *", &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
+    assert execute({"@annually", &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({"@annually", &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
+    assert execute({"@yearly",   &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({"@yearly",   &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
   end
 
   test "parse */5" do
-    assert execute({"*/5 * * * *", &ok/0, []}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
+    assert execute({"*/5 * * * *", &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
   end
 
   test "parse 5" do
-    assert execute({"5 * * * *",  &ok/0, []}, %{d: {2015, 12, 31}, h: 12, m: 5, w: 1}) == :ok
+    assert execute({"5 * * * *",  &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 5, w: 1}) == :ok
   end
 
   test "counter example" do
-    execute({"5 * * * *", &flunk/0, []}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1})
+    execute({"5 * * * *", &flunk/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1})
   end
 
   test "function as tuple" do
-    assert execute({"* * * * *", {__MODULE__, :ok}, []}, %{}) == :ok
-    assert execute({"* * * * *", {"Quantum.ExecutorTest", "ok"}, []}, %{}) == :ok
+    assert execute({"* * * * *", {__MODULE__, :ok}, [], @default_timezone}, %{}) == :ok
+    assert execute({"* * * * *", {"Quantum.ExecutorTest", "ok"}, [], @default_timezone}, %{}) == :ok
   end
 
   test "readable schedule" do
-    assert execute({"@weekly", {__MODULE__, :ok}, []}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({"@weekly", {__MODULE__, :ok}, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, w: 0}) == :ok
   end
 
   test "function with args" do
-    assert execute({"* * * * *", &ret/1, [:passed]}, %{}) == :passed
+    assert execute({"* * * * *", &ret/1, [:passed], @default_timezone}, %{}) == :passed
   end
 
   test "reboot" do
-    assert execute({"@reboot", &ok/0, []}, %{r: 1}) == :ok
-    assert execute({"@reboot", &ok/0, []}, %{r: 0}) == false
+    assert execute({"@reboot", &ok/0, [], @default_timezone}, %{r: 1}) == :ok
+    assert execute({"@reboot", &ok/0, [], @default_timezone}, %{r: 0}) == false
   end
 
 end


### PR DESCRIPTION
This is by no means a finalized pull request, just a draft regarding #88 since you showed interest in it. The change adds optional per-job timezone support and is therefore backwards compatible -- current `Quantum` users should see no change in behavior.

A couple obvious things:
* `README.md` needs to be improved to demonstrate the new timezone features
* Test suite for a timezone other than default (UTC) should be written
* `w` field in `Executor` state is now obsolete/unused and should be removed, as weekday is calculated by `Timex` now

However before I write those things, I just wanted to get your feedback on the design of this feature; code quality, adherence to standards, and a second set of eyes to see if I missed something. The big differences that might be controversial are:

* Dependency on `Timex` library, which has a follow-up dependency on `Tzdata`; previously the `Quantum` library had no dependencies.
* `Quantum.Job`s will default to compile-time configuration default timezone, whereas `Quantum.Timer` loads that configuration on the fly -- could this be confusing?

Thanks.