### PR TITLE
Solution: moved %Quantum.Jobs{nodes: ...} defaulting to the normalizer, to execute defaulting logic at the time the job is actually added to the scheduler.

### DIFF
--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -14,7 +14,7 @@ defmodule Quantum.Job do
     task: nil, # {module, function}
     args: @default_args,
     state: :active, # active/inactive
-    nodes: Application.get_env(:quantum, :default_nodes, [node()]),
+    nodes: nil,
     # @default_nodes,
     overlap: @default_overlap,
     pid: nil,

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -14,7 +14,6 @@ defmodule Quantum.Job do
     args: @default_args,
     state: :active, # active/inactive
     nodes: nil,
-    # @default_nodes,
     overlap: @default_overlap,
     pid: nil,
     timezone: @default_timezone

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -4,7 +4,7 @@ defmodule Quantum.Job do
 
   @default_schedule Application.get_env(:quantum, :default_schedule, nil)
   @default_args     Application.get_env(:quantum, :default_args, [])
-  @default_nodes    Application.get_env(:quantum, :default_nodes, [node()])
+  #@default_nodes    Application.get_env(:quantum, :default_nodes, [node()])
   @default_overlap  Application.get_env(:quantum, :default_overlap, true)
   @default_timezone Application.get_env(:quantum, :timezone, :utc)
 
@@ -14,12 +14,17 @@ defmodule Quantum.Job do
     task: nil, # {module, function}
     args: @default_args,
     state: :active, # active/inactive
-    nodes: @default_nodes,
+    nodes: Application.get_env(:quantum, :default_nodes, [node()]),
+    # @default_nodes,
     overlap: @default_overlap,
     pid: nil,
     timezone: @default_timezone
   ]
 
   @type t :: %Quantum.Job{}
+
+  def get_default_nodes() do
+    Application.get_env(:quantum, :default_nodes, [node()])
+  end
 
 end

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -4,7 +4,6 @@ defmodule Quantum.Job do
 
   @default_schedule Application.get_env(:quantum, :default_schedule, nil)
   @default_args     Application.get_env(:quantum, :default_args, [])
-  #@default_nodes    Application.get_env(:quantum, :default_nodes, [node()])
   @default_overlap  Application.get_env(:quantum, :default_overlap, true)
   @default_timezone Application.get_env(:quantum, :timezone, :utc)
 
@@ -22,9 +21,5 @@ defmodule Quantum.Job do
   ]
 
   @type t :: %Quantum.Job{}
-
-  def get_default_nodes() do
-    Application.get_env(:quantum, :default_nodes, [node()])
-  end
 
 end

--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -9,6 +9,10 @@ defmodule Quantum.Normalizer do
     {nj.name, nj}
   end
 
+  def default_nodes do
+    Application.get_env(:quantum, :default_nodes, [node()])
+  end
+
   # Creates named Quantum.Job
   # Input:
   # [
@@ -27,7 +31,13 @@ defmodule Quantum.Normalizer do
   # }
   defp normalize_job({job_name, %Quantum.Job{} = job}) do
     # Sets defauts for job if necessary
-    job_name |> job_opts([]) |> Map.merge(%{job | name: job_name, nodes: Application.get_env(:quantum, :default_nodes, [node()])})
+    job_name |> job_opts([]) |> Map.merge(%{job | name: job_name})
+    |> Map.put(
+        :nodes,
+        case job.nodes do
+          nil -> default_nodes
+          ns -> ns
+        end)
   end
 
   defp normalize_job({job_name, opts}) when opts |> is_list or opts |> is_map do

--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -27,7 +27,7 @@ defmodule Quantum.Normalizer do
   # }
   defp normalize_job({job_name, %Quantum.Job{} = job}) do
     # Sets defauts for job if necessary
-    job_name |> job_opts([]) |> Map.merge(%{job | name: job_name})
+    job_name |> job_opts([]) |> Map.merge(%{job | name: job_name, nodes: Application.get_env(:quantum, :default_nodes, [node()])})
   end
 
   defp normalize_job({job_name, opts}) when opts |> is_list or opts |> is_map do

--- a/test/normalizer_test.exs
+++ b/test/normalizer_test.exs
@@ -37,7 +37,8 @@ defmodule Quantum.NormalizerTest do
       name: nil,
       schedule: "* * * * *",
       task: {"MyModule", "my_method"},
-      args: []
+      args: [],
+      nodes: default_nodes
     }}
   end
 
@@ -48,7 +49,8 @@ defmodule Quantum.NormalizerTest do
       name: nil,
       schedule: "* * * * *",
       task: {"MyModule", "my_method"},
-      args: []
+      args: [],
+      nodes: default_nodes
     }}
   end
 
@@ -59,7 +61,8 @@ defmodule Quantum.NormalizerTest do
       name: nil,
       schedule: "* * * * *",
       task: {"MyModule", "my_method"},
-      args: [1, 2, 3]
+      args: [1, 2, 3],
+      nodes: default_nodes
     }}
   end
 
@@ -70,7 +73,8 @@ defmodule Quantum.NormalizerTest do
       name: nil,
       schedule: "@weekly",
       task: {"MyModule", "my_method"},
-      args: []
+      args: [],
+      nodes: default_nodes
     }}
   end
 

--- a/test/quantum_test.exs
+++ b/test/quantum_test.exs
@@ -38,6 +38,17 @@ defmodule QuantumTest do
     end
   end
 
+  test "adding a named {m, f, a} jpb at run time" do
+    name = "ticker"
+    spec = "1 * * * *"
+    task = {IO, :puts}
+    args = ["Tick"]
+    job = %Quantum.Job{schedule: spec, task: task, args: args}
+    :ok = Quantum.add_job(name, job)
+    assert Enum.member? Quantum.jobs, {name, %{job | name: name,
+                                                     nodes: [node()]}}
+  end
+
   test "adding a unnamed job at run time" do
     spec = "1 * * * *"
     fun = fn -> :ok end

--- a/test/quantum_test.exs
+++ b/test/quantum_test.exs
@@ -90,7 +90,7 @@ defmodule QuantumTest do
     for name <- job_names do
       spec = "* * * * *"
       fun = fn -> :ok end
-      job = %Quantum.Job{name: name, schedule: spec, task: fun}
+      job = %Quantum.Job{name: name, schedule: spec, task: fun, nodes: Quantum.Normalizer.default_nodes}
       :ok = Quantum.add_job(name, job)
       :ok = Quantum.deactivate_job(name)
       sjob = Quantum.find_job(name)
@@ -102,7 +102,7 @@ defmodule QuantumTest do
     for name <- job_names do
       spec = "* * * * *"
       fun = fn -> :ok end
-      job = %Quantum.Job{name: name, schedule: spec, task: fun, state: :inactive}
+      job = %Quantum.Job{name: name, schedule: spec, task: fun, state: :inactive, nodes: Quantum.Normalizer.default_nodes}
 
       :ok = Quantum.add_job(name, job)
       :ok = Quantum.activate_job(name)
@@ -164,7 +164,7 @@ defmodule QuantumTest do
       Agent.update(pid1, fn(_) -> fun_pid end)
       Agent.update(pid2, fn(n) -> n + 1 end)
     end
-    job = %Quantum.Job{schedule: "* * * * *", task: fun}
+    job = %Quantum.Job{schedule: "* * * * *", task: fun, nodes: Quantum.Normalizer.default_nodes}
     state1 = %{jobs: [{nil, job}], d: d, h: h, m: m - 1, w: nil, r: 0}
     state3 = Quantum.handle_info(:tick, state1)
     :timer.sleep(500)
@@ -197,7 +197,7 @@ defmodule QuantumTest do
       Agent.update(pid1, fn(_) -> fun_pid end)
       Agent.update(pid2, fn(n) -> n + 1 end)
     end
-    job = %Quantum.Job{schedule: "@reboot", task: fun}
+    job = %Quantum.Job{schedule: "@reboot", task: fun, nodes: Quantum.Normalizer.default_nodes}
     {:ok, state} = Quantum.init(%{jobs: [{nil, job}], d: nil, h: nil, m: nil, w: nil, r: nil})
     :timer.sleep(500)
     job = %{job | pid: Agent.get(pid1, fn(n) -> n end)}
@@ -216,7 +216,7 @@ defmodule QuantumTest do
       Agent.update(pid1, fn(_) -> fun_pid end)
       Agent.update(pid2, fn(n) -> n + 1 end)
     end
-    job = %Quantum.Job{schedule: "* * * * *", task: fun, overlap: false}
+    job = %Quantum.Job{schedule: "* * * * *", task: fun, overlap: false, nodes: Quantum.Normalizer.default_nodes}
     state1 = %{jobs: [{nil, job}], d: d, h: h, m: m - 1, w: nil, r: 0}
     state3 = Quantum.handle_info(:tick, state1)
     :timer.sleep(500)
@@ -237,7 +237,7 @@ defmodule QuantumTest do
       Agent.update(pid1, fn(_) -> fun_pid end)
       Agent.update(pid2, fn(n) -> n + 1 end)
     end
-    job = %Quantum.Job{schedule: "* * * * *", task: fun, overlap: false, pid: pid1}
+    job = %Quantum.Job{schedule: "* * * * *", task: fun, overlap: false, pid: pid1, nodes: Quantum.Normalizer.default_nodes}
     state1 = %{jobs: [{nil, job}], d: d, h: h, m: m - 1, w: nil, r: 0}
     state3 = Quantum.handle_info(:tick, state1)
     :timer.sleep(500)


### PR DESCRIPTION
Moved defaulting logic for nodes property of the %Quantum.Job struict to the normalizer to make a runtime call at the time the job is actually added to the scheduler, instead of using a wrong static value.

Added public functon default_nodes to the Quantum.Normalizer module in order to explicitly set nodes property in the %Quantum.Job{} struct in tests that explicitly validate nodes property.

Fixes #89 Fixes #93 