### PR TITLE
Update Timex to avoid Elixir v1.3 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Quantum.Mixfile do
       app: :quantum,
       build_embedded: Mix.env == :prod,
       deps: [
-        {:timex,       "~> 2.1"},
+        {:timex,       "~> 2.2"},
         {:credo,       "~> 0.3",  only: [:dev, :test]},
         {:earmark,     "~> 0.2",  only: [:dev, :docs]},
         {:ex_doc,      "~> 0.11", only: [:dev, :docs]},


### PR DESCRIPTION
Timex has been updated to avoid compilation warnings on v1.3, so it'd be nice for Quantum to use their v2.2.x 