### PR TITLE
Problem: Quantum incompatible with Timex 3.0

### DIFF
--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -15,8 +15,8 @@ defmodule Quantum.Executor do
     end
 
     case Application.get_env(:quantum, :timezone, :utc) do
-      :utc   -> t |> DateTime.from |> Timezone.convert(tz_final)
-      :local -> t |> DateTime.from(:local) |> Timezone.convert(tz_final)
+      :utc   -> t |> Timex.to_datetime |> Timezone.convert(tz_final)
+      :local -> t |> Timex.to_datetime(:local) |> Timezone.convert(tz_final)
       tz     -> raise "Unsupported timezone: #{tz}"
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Quantum.Mixfile do
       app: :quantum,
       build_embedded: Mix.env == :prod,
       deps: [
-        {:timex,       "~> 2.2"},
+        {:timex,       "~> 3.0"},
         {:credo,       "~> 0.3",  only: [:dev, :test]},
         {:earmark,     "~> 0.2",  only: [:dev, :docs]},
         {:ex_doc,      "~> 0.11", only: [:dev, :docs]},


### PR DESCRIPTION
Currently, Quantum relies on an older version of Timex.

This PR upgrades the Timex dependency to the latest 3.0. The `Timex.DateTime.from` call, which has been deprecated, is replaced with the equivalent `Timex.to_datetime`.