### PR TITLE
Remove unused alias DateTime

### DIFF
--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -3,7 +3,6 @@ defmodule Quantum.Executor do
   @moduledoc false
 
   alias Timex.Timezone
-  alias Timex.DateTime
   import Quantum.Matcher
 
   def convert_to_timezone(s, tz) do


### PR DESCRIPTION
This Pull Request removes a compiler warning

```
warning: unused alias DateTime
```