### PR TITLE
Solution: Timezone as string not working in config

### DIFF
--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -16,7 +16,8 @@ defmodule Quantum.Executor do
     case Application.get_env(:quantum, :timezone, :utc) do
       :utc   -> t |> Timex.to_datetime |> Timezone.convert(tz_final)
       :local -> t |> Timex.to_datetime(:local) |> Timezone.convert(tz_final)
-      tz     -> raise "Unsupported timezone: #{tz}"
+      tz     ->
+        t |> Timex.to_datetime(tz_final)
     end
   end
 

--- a/lib/quantum/timer.ex
+++ b/lib/quantum/timer.ex
@@ -1,5 +1,5 @@
 defmodule Quantum.Timer do
-
+  alias Timex.Timezone
   @moduledoc false
 
   def timezone_function do
@@ -9,7 +9,7 @@ defmodule Quantum.Timer do
       :local ->
         &:calendar.now_to_local_time/1
       timezone ->
-        raise "Unsupported timezone: #{timezone}"
+        &custom(timezone, &1)
     end
   end
 
@@ -19,4 +19,7 @@ defmodule Quantum.Timer do
     {d, h, m}
   end
 
+  def custom(timezone, time) do
+    Timex.now(timezone) |> Timex.to_erl
+  end
 end

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -21,6 +21,8 @@ defmodule Quantum.ExecutorTest do
           Application.put_env(:timex, :local_timezone, "Etc/GMT+1")
         "CET" ->
           Application.put_env(:quantum, :timezone, "Etc/GMT+1")
+        "America/Chicago" ->
+          Application.put_env(:quantum, :timezone, "America/Chicago")
       end
     end
 
@@ -106,9 +108,12 @@ defmodule Quantum.ExecutorTest do
   end
 
   @tag timezone: "CET"
-  test "rejects arbitrary timezone" do
-    assert_raise RuntimeError, ~r/Unsupported timezone/, fn ->
-      execute({"@daily", &ok/0, [], "Etc/GMT+1"}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1})
-    end
+  test "accepts custom timezones" do
+    assert execute({"@daily", &ok/0, [], "Etc/GMT+1"}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
+  end
+
+  @tag timezone: "America/Chicago"
+  test "accepts custom timezones(America/Chicago)" do
+    assert execute({"@daily", &ok/0, [], "America/Chicago"}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
   end
 end

--- a/test/timer_test.exs
+++ b/test/timer_test.exs
@@ -12,20 +12,10 @@ defmodule Quantum.TimerTest do
     {d_local, {h_local, m_local, _}} = :calendar.now_to_local_time(:os.timestamp)
     assert Quantum.Timer.tick == {d_local, h_local, m_local}
 
+    Application.put_env(:quantum, :timezone, "America/Chicago")
+    {d_local, {h_local, m_local, _}} = Quantum.Timer.custom("America/Chicago", :os.timestamp)
+    assert Quantum.Timer.tick == {d_local, h_local, m_local}
+
     Application.put_env(:quantum, :timezone, current_time_zone)
   end
-
-  test "timezone_function function raises error when timezone is set incorrectly" do
-    current_time_zone = Application.get_env(:quantum, :timezone, :utc)
-
-    try do
-      Application.put_env(:quantum, :timezone, "test-time-zone")
-      assert_raise RuntimeError, "Unsupported timezone: test-time-zone", fn ->
-        Quantum.Timer.timezone_function
-      end
-    after
-      Application.put_env(:quantum, :timezone, current_time_zone)
-    end
-  end
-
 end


### PR DESCRIPTION
I took a shot at issue #108 . I came a solution that so far has been working for me, but this might need more testing. 

I also adapted the tests accordingly.

In case you have comments or suggestions on how to solve this in a better way, I'm open on improving the PR.