### PR TITLE
Don't allow "local" timezone. Replace Timex w. Calendar.

### DIFF
--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -2,22 +2,21 @@ defmodule Quantum.Executor do
 
   @moduledoc false
 
-  alias Timex.Timezone
   import Quantum.Matcher
 
   def convert_to_timezone(s, tz) do
-    t = {s.d, {s.h, s.m, 0}}  # Convert to erlang datetime
+    dt = {s.d, {s.h, s.m, 0}}  # erlang datetime
+
     tz_final = case tz do
-      :utc   -> Timezone.get("UTC")
-      :local -> Timezone.local()
+      :utc   -> "Etc/UTC"
+      :local -> raise "error - local timezone not allowed"
       tz0    -> tz0
     end
 
     case Application.get_env(:quantum, :timezone, :utc) do
-      :utc   -> t |> Timex.to_datetime |> Timezone.convert(tz_final)
-      :local -> t |> Timex.to_datetime(:local) |> Timezone.convert(tz_final)
-      tz     ->
-        t |> Timex.to_datetime(tz_final)
+      :utc   -> dt |> Calendar.DateTime.from_erl!("Etc/UTC") |> Calendar.DateTime.shift_zone!(tz_final)
+      :local -> raise "error - local timezone not allowed"
+      _      -> dt |> Calendar.DateTime.from_erl!(tz_final)
     end
   end
 
@@ -43,7 +42,7 @@ defmodule Quantum.Executor do
 
   def execute({"@weekly", fun, args, tz}, state) do
     c = convert_to_timezone(state, tz)
-    c_weekday = rem(Timex.weekday(c), 7)
+    c_weekday = Calendar.Date.day_of_week_zb(c)
     if c.minute == 0 and c.hour == 0 and c_weekday == 0 do
       execute_fun(fun, args)
     else
@@ -82,7 +81,7 @@ defmodule Quantum.Executor do
     [m, h, d, n, w] = e |> String.split(" ")
 
     c = convert_to_timezone(state, tz)
-    c_weekday = rem(Timex.weekday(c), 7)
+    c_weekday = Calendar.Date.day_of_week_zb(c)
 
     cond do
       !match(m, c.minute,  0..59) -> false

--- a/lib/quantum/timer.ex
+++ b/lib/quantum/timer.ex
@@ -1,5 +1,4 @@
 defmodule Quantum.Timer do
-  alias Timex.Timezone
   @moduledoc false
 
   def timezone_function do
@@ -19,7 +18,7 @@ defmodule Quantum.Timer do
     {d, h, m}
   end
 
-  def custom(timezone, time) do
-    Timex.now(timezone) |> Timex.to_erl
+  def custom(timezone, _) do
+    Calendar.DateTime.now!(timezone) |> Calendar.DateTime.to_erl
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Quantum.Mixfile do
       app: :quantum,
       build_embedded: Mix.env == :prod,
       deps: [
-        {:timex,       "~> 3.0"},
+        {:calendar,    "~> 0.16"},
         {:credo,       "~> 0.4",  only: [:dev, :test]},
         {:earmark,     "~> 1.0",  only: [:dev, :docs]},
         {:ex_doc,      "~> 0.13", only: [:dev, :docs]},
@@ -31,7 +31,7 @@ defmodule Quantum.Mixfile do
   end
 
   def application do
-    [applications: [:timex], mod: {Quantum.Application, []}]
+    [applications: [:calendar], mod: {Quantum.Application, []}]
   end
 
   defp package do

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -12,13 +12,11 @@ defmodule Quantum.ExecutorTest do
     if timezone = context[:timezone] do
       on_exit(context, fn ->
         Application.delete_env(:quantum, :timezone)
-        Application.delete_env(:timex, :local_timezone)
       end)
 
       case timezone do
         "local" ->
           Application.put_env(:quantum, :timezone, :local)
-          Application.put_env(:timex, :local_timezone, "Etc/GMT+1")
         "CET" ->
           Application.put_env(:quantum, :timezone, "Etc/GMT+1")
         "America/Chicago" ->
@@ -103,8 +101,8 @@ defmodule Quantum.ExecutorTest do
   end
 
   @tag timezone: "local"
-  test "accepts local timezone" do
-    assert execute({"@daily", &ok/0, [], :local}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
+  test "Raise if trying to use 'local' timezone" do
+    assert assert_raise(RuntimeError, fn -> execute({"@daily", &ok/0, [], :local}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) end)
   end
 
   @tag timezone: "CET"


### PR DESCRIPTION
Depending on a "local" timezone global variable is a bad idea. See more here: http://www.creativedeletion.com/2015/08/07/why-not-to-use-server-local-time.html