### PR TITLE
Problem: global cannot be used directly

### DIFF
--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -79,7 +79,13 @@ defmodule Quantum do
 
   @doc "Starts Quantum process"
   def start_link(state) do
-    GenServer.start_link(__MODULE__, state, [name: @quantum])
+    case GenServer.start_link(__MODULE__, state, [name: @quantum]) do
+      {:ok, pid} ->
+        {:ok, pid}
+      {:error, {:already_started, pid}} ->
+        Process.link(pid)
+        {:ok, pid}
+    end
   end
 
   def init(s) do


### PR DESCRIPTION
To run quantum as a global process with the current implement, I have to start quantum manually so I can deal with the crash in `start_link` for `already_started` process.

Solution: It should really be handled directly in quantum `start_link`, so all we need is the `global?` config to run quantum as a global process!

(slowly correcting the things I added)