### PR TITLE
add ability to specify genserver timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   * [Crontab format](#crontab-format)
   * [Special expressions](#special-expressions)
   * [Override default settings](#override-default-settings)
+  * [GenServer timeout](#genserver-timeout)
 * [Contribution](#contribution)
 * [License](#license)
 
@@ -244,6 +245,24 @@ config :quantum,
   default_args: ["my api key"],
   default_nodes: [:app1@myhost],
   default_overlap: false
+```
+
+### GenServer timeout
+
+Sometimes, you may come across GenServer timeout errors esp. when you have
+too many jobs or high load. The default `GenServer.call` timeout is 5000.
+You can override this default by specifying `timeout` setting in configuration.
+
+```elixir
+config :quantum,
+  timeout: 30_000
+```
+
+Or if you wish to wait indefinitely:
+
+```elixir
+config :quantum,
+  timeout: :infinity
 ```
 
 ### Run Quantum as a global process

--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -27,7 +27,7 @@ defmodule Quantum do
   @doc "Adds a new unnamed job"
   @spec add_job(job) :: :ok
   def add_job(job) do
-    GenServer.call(@quantum, {:add, Normalizer.normalize({nil, job})})
+    GenServer.call(@quantum, {:add, Normalizer.normalize({nil, job})}, timeout)
   end
 
   @doc "Adds a new named job"
@@ -37,20 +37,20 @@ defmodule Quantum do
     if name && find_job(name) do
       :error
     else
-      GenServer.call(@quantum, {:add, {name, job}})
+      GenServer.call(@quantum, {:add, {name, job}}, timeout)
     end
   end
 
   @doc "Deactivates a job by name"
   @spec deactivate_job(expr) :: :ok
   def deactivate_job(n) do
-    GenServer.call(@quantum, {:change_state, n, :inactive})
+    GenServer.call(@quantum, {:change_state, n, :inactive}, timeout)
   end
 
   @doc "Activates a job by name"
   @spec activate_job(expr) :: :ok
   def activate_job(n) do
-    GenServer.call(@quantum, {:change_state, n, :active})
+    GenServer.call(@quantum, {:change_state, n, :active}, timeout)
   end
 
   @doc "Resolves a job by name"
@@ -62,19 +62,19 @@ defmodule Quantum do
   @doc "Deletes a job by name"
   @spec delete_job(expr) :: job
   def delete_job(name) do
-    GenServer.call(@quantum, {:delete, name})
+    GenServer.call(@quantum, {:delete, name}, timeout)
   end
 
   @doc "Deletes all jobs"
   @spec delete_all_jobs :: :ok
   def delete_all_jobs do
-    GenServer.call(@quantum, {:delete_all})
+    GenServer.call(@quantum, {:delete_all}, timeout)
   end
 
   @doc "Returns the list of currently defined jobs"
   @spec jobs :: [job]
   def jobs do
-    GenServer.call(@quantum, :jobs)
+    GenServer.call(@quantum, :jobs, timeout)
   end
 
   @doc "Starts Quantum process"
@@ -154,5 +154,7 @@ defmodule Quantum do
       {_name, job} -> job
     end
   end
+
+  defp timeout, do: Application.get_env(:quantum, :timeout, 5_000)
 
 end

--- a/test/quantum_test.exs
+++ b/test/quantum_test.exs
@@ -325,6 +325,14 @@ defmodule QuantumTest do
     assert Enum.count(Quantum.jobs) == 2
   end
 
+  test "timeout can be configured for genserver correctly" do
+    Application.put_env(:quantum, :timeout, 0)
+    job = %Quantum.Job{schedule: "* */5 * * *", task: fn -> :ok end}
+    assert catch_exit(Quantum.add_job(:tmpjob, job)) == {:timeout, {GenServer, :call, [Quantum, :jobs, 0]}}
+  after
+    Application.delete_env(:quantum, :timeout)
+  end
+
   # loop until given process is alive
   defp ensure_alive(pid) do
     case Process.alive?(pid) do


### PR DESCRIPTION
We have several hundred background jobs and their number were increasing each day until we hit GenServer time out. This allows ability to specify `timeout` as part of quantum config. What do you think?

Something like below causes timeout on my system (which has relatively high load) for eg:

```
1..10_000 |> Enum.map(fn x -> Quantum.add_job("#{x}",  %Quantum.Job{schedule: "* */5 * * *", task: fn -> :ok end}) end)
```