### PR TITLE
#105 Support Second Granularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Cron Expressions can now be provided via the `%Crontab.CronExpression{}` struct or via the `~e[CRON EXPRESSION]` sigil.
+- Cron Expressions can now be extended. This way second granularity of the expressions can be provided.
 
 ## [1.8.1] - 2016-11-20
 ### Changed

--- a/README.md
+++ b/README.md
@@ -164,6 +164,38 @@ Quantum.delete_job(:ticker)
 # %Quantum.Job{...}
 ```
 
+### Jobs with Second granularity
+
+It is possible to specify jobs with second granularity.
+To do this the `schedule` parameter has to be provided with either a `%Crontab.CronExpression{extended: true, ...}` or
+with a set `e` flag on the `e` sigil. (The sigil must be imported from `Crontab.CronExpression`)
+
+With Sigil:
+```elixir
+import Crontab.CronExpression
+
+config :quantum, cron: [
+  news_letter: [
+    schedule: ~[*/2]e, # Runs every two seconds
+    task: "MyApp.NewsLetter.send", # {MyApp.NewsLetter, :send} is supported too
+    args: [:whatever]
+  ]
+]
+```
+
+With Struct:
+```elixir
+config :quantum, cron: [
+  news_letter: [
+    schedule: %Crontab.CronExpression{extended: true, second: [5]}, # Runs every minute at second 5
+    task: "MyApp.NewsLetter.send", # {MyApp.NewsLetter, :send} is supported too
+    args: [:whatever]
+  ]
+]
+```
+
+The struct & sigil are documented here: https://hexdocs.pm/crontab/Crontab.CronExpression.html
+
 ### Nodes
 
 If you need to run a job on a certain node you can define:

--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -128,11 +128,11 @@ defmodule Quantum do
     {:reply, children, s}
   end
 
-  def handle_info(:tick, s) do
-    {d, h, m} = Timer.tick
-    s = if s.d != d, do: %{s | d: d, w: rem(:calendar.day_of_the_week(d), 7)}, else: s
-    s = %{s | h: h, m: m}
-    {:noreply, %{s | jobs: run(s)}}
+  def handle_info(:tick, state) do
+    {d, h, m, s} = Timer.tick
+    state = if state.d != d, do: %{state | d: d, w: rem(:calendar.day_of_the_week(d), 7)}, else: state
+    state = %{state | h: h, m: m, s: s}
+    {:noreply, %{state | jobs: run(state)}}
   end
   def handle_info(_, s), do: {:noreply, s}
 

--- a/lib/quantum/application.ex
+++ b/lib/quantum/application.ex
@@ -11,7 +11,7 @@ defmodule Quantum.Application do
     jobs = :quantum |> Application.get_env(:cron, [])
     |> Enum.map(&normalize/1)
     |> remove_jobs_with_duplicate_names
-    state = %{jobs: jobs, d: nil, h: nil, m: nil, w: nil, r: nil}
+    state = %{jobs: jobs, d: nil, h: nil, m: nil, s: nil, w: nil, r: nil}
     Quantum.Supervisor.start_link(state)
   end
 

--- a/lib/quantum/timer.ex
+++ b/lib/quantum/timer.ex
@@ -13,9 +13,10 @@ defmodule Quantum.Timer do
   end
 
   def tick do
+    miliseconds = 1000 - (:os.system_time(:millisecond) - :os.system_time(:seconds) * 1000)
+    Process.send_after(self(), :tick, miliseconds)
     {d, {h, m, s}} = timezone_function().(:os.timestamp)
-    Process.send_after(self(), :tick, (60 - s) * 1000)
-    {d, h, m}
+    {d, h, m, s}
   end
 
   def custom(timezone, _) do

--- a/lib/quantum/timer.ex
+++ b/lib/quantum/timer.ex
@@ -13,8 +13,9 @@ defmodule Quantum.Timer do
   end
 
   def tick do
-    miliseconds = 1000 - (:os.system_time(:millisecond) - :os.system_time(:seconds) * 1000)
-    Process.send_after(self(), :tick, miliseconds)
+    {_, _, ms_raw} = :os.timestamp()
+    ms = 1000 - :erlang.round(ms_raw / 1000)
+    Process.send_after(self(), :tick, ms)
     {d, {h, m, s}} = timezone_function().(:os.timestamp)
     {d, h, m, s}
   end

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -2,7 +2,7 @@ defmodule Quantum.ExecutorTest do
   use ExUnit.Case
 
   @default_timezone Application.get_env(:quantum, :timezone, :utc)
-  @default_date %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}
+  @default_date %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}
 
   import Quantum.Executor
   import Crontab.CronExpression
@@ -34,54 +34,54 @@ defmodule Quantum.ExecutorTest do
   end
 
   test "check hourly" do
-    assert execute({~e[0 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
-    assert execute({~e[0 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, w: 1}) == false
-    assert execute({~e[@hourly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
-    assert execute({~e[@hourly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, w: 1}) == false
+    assert execute({~e[0 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[0 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, s: 0, w: 1}) == false
+    assert execute({~e[@hourly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@hourly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, s: 0, w: 1}) == false
   end
 
   test "check daily" do
-    assert execute({~e[0 0 * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
-    assert execute({~e[0 0 * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
-    assert execute({~e[@daily],    &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
-    assert execute({~e[@daily],    &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
-    assert execute({~e[@midnight], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
-    assert execute({~e[@midnight], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, w: 1}) == false
+    assert execute({~e[0 0 * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[0 0 * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
+    assert execute({~e[@daily],    &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@daily],    &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
+    assert execute({~e[@midnight], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@midnight], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
   end
 
   test "check weekly" do
-    assert execute({~e[0 0 * * 0], &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({~e[0 0 * * 0], &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, w: 0}) == false
-    assert execute({~e[@weekly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({~e[@weekly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, w: 0}) == false
+    assert execute({~e[0 0 * * 0], &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[0 0 * * 0], &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[@weekly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@weekly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, s: 0, w: 0}) == false
   end
 
   test "check monthly" do
-    assert execute({~e[0 0 1 * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({~e[0 0 1 * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, w: 0}) == false
-    assert execute({~e[@monthly],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({~e[@monthly],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, w: 0}) == false
+    assert execute({~e[0 0 1 * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[0 0 1 * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[@monthly],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@monthly],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, s: 0, w: 0}) == false
   end
 
   test "check yearly" do
-    assert execute({~e[0 0 1 1 *], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({~e[0 0 1 1 *], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
-    assert execute({~e[@annually], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({~e[@annually], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
-    assert execute({~e[@yearly],   &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, w: 0}) == :ok
-    assert execute({~e[@yearly],   &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, w: 0}) == false
+    assert execute({~e[0 0 1 1 *], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[0 0 1 1 *], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[@annually], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@annually], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[@yearly],   &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@yearly],   &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
   end
 
   test "parse */5" do
-    assert execute({~e[*/5 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1}) == :ok
+    assert execute({~e[*/5 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
   end
 
   test "parse 5" do
-    assert execute({~e[5 * * * *],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 5, w: 1}) == :ok
+    assert execute({~e[5 * * * *],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 5, s: 0, w: 1}) == :ok
   end
 
   test "counter example" do
-    execute({~e[5 * * * *], &flunk/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, w: 1})
+    execute({~e[5 * * * *], &flunk/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1})
   end
 
   test "function as tuple" do
@@ -90,7 +90,7 @@ defmodule Quantum.ExecutorTest do
   end
 
   test "readable schedule" do
-    assert execute({~e[@weekly], {__MODULE__, :ok}, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, w: 0}) == :ok
+    assert execute({~e[@weekly], {__MODULE__, :ok}, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
   end
 
   test "function with args" do
@@ -104,16 +104,16 @@ defmodule Quantum.ExecutorTest do
 
   @tag timezone: "local"
   test "Raise if trying to use 'local' timezone" do
-    assert assert_raise(RuntimeError, fn -> execute({"@daily", &ok/0, [], :local}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) end)
+    assert assert_raise(RuntimeError, fn -> execute({~e[@daily], &ok/0, [], :local}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) end)
   end
 
   @tag timezone: "CET"
   test "accepts custom timezones" do
-    assert execute({~e[@daily], &ok/0, [], "Etc/GMT+1"}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
+    assert execute({~e[@daily], &ok/0, [], "Etc/GMT+1"}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
   end
 
   @tag timezone: "America/Chicago"
   test "accepts custom timezones(America/Chicago)" do
-    assert execute({~e[@daily], &ok/0, [], "America/Chicago"}, %{d: {2015, 12, 31}, h: 0, m: 0, w: 1}) == :ok
+    assert execute({~e[@daily], &ok/0, [], "America/Chicago"}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
   end
 end

--- a/test/timer_test.exs
+++ b/test/timer_test.exs
@@ -5,16 +5,16 @@ defmodule Quantum.TimerTest do
     current_time_zone = Application.get_env(:quantum, :timezone, :utc)
 
     Application.put_env(:quantum, :timezone, :utc)
-    {d_utc, {h_utc, m_utc, _}} = :calendar.now_to_universal_time(:os.timestamp)
-    assert Quantum.Timer.tick == {d_utc, h_utc, m_utc}
+    {d_utc, {h_utc, m_utc, s_utc}} = :calendar.now_to_universal_time(:os.timestamp)
+    assert Quantum.Timer.tick == {d_utc, h_utc, m_utc, s_utc}
 
     Application.put_env(:quantum, :timezone, :local)
-    {d_local, {h_local, m_local, _}} = :calendar.now_to_local_time(:os.timestamp)
-    assert Quantum.Timer.tick == {d_local, h_local, m_local}
+    {d_local, {h_local, m_local, s_local}} = :calendar.now_to_local_time(:os.timestamp)
+    assert Quantum.Timer.tick == {d_local, h_local, m_local, s_local}
 
     Application.put_env(:quantum, :timezone, "America/Chicago")
-    {d_local, {h_local, m_local, _}} = Quantum.Timer.custom("America/Chicago", :os.timestamp)
-    assert Quantum.Timer.tick == {d_local, h_local, m_local}
+    {d_local, {h_local, m_local, s_local}} = Quantum.Timer.custom("America/Chicago", :os.timestamp)
+    assert Quantum.Timer.tick == {d_local, h_local, m_local, s_local}
 
     Application.put_env(:quantum, :timezone, current_time_zone)
   end

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -9,19 +9,19 @@ defmodule Quantum.TimezoneTest do
 
   test "check timezones" do
     # We choose timezones with no daylight savings time or other weird things going on, so that these tests can pass at all times
-    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+2"}, %{d: {2015, 12, 15}, h: 23, m: 0, w: 1}) == :ok
-    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+3"}, %{d: {2015, 12, 16}, h: 0, m: 0, w: 1}) == :ok
-    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+3"}, %{d: {2015, 12, 15}, h: 0, m: 0, w: 1}) == false
+    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+2"}, %{d: {2015, 12, 15}, h: 23, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+3"}, %{d: {2015, 12, 16}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+3"}, %{d: {2015, 12, 15}, h: 0, m: 0, s: 0, w: 1}) == false
   end
 
   test "check timezone with weekly" do
-    assert execute({~e[@weekly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 5}, h: 21, m: 0, w: 1}) == :ok
-    assert execute({~e[@weekly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 6}, h: 0, m: 0, w: 1}) == false
+    assert execute({~e[@weekly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 5}, h: 21, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@weekly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 6}, h: 0, m: 0, s: 0, w: 1}) == false
   end
 
   test "check timezone with monthly" do
-    assert execute({~e[@monthly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 2, 29}, h: 21, m: 0, w: 1}) == :ok
-    assert execute({~e[@monthly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 1}, h: 0, m: 0, w: 1}) == false
+    assert execute({~e[@monthly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 2, 29}, h: 21, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@monthly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 1}, h: 0, m: 0, s: 0, w: 1}) == false
   end
 
 end


### PR DESCRIPTION
Implementation of #105

## Feature

Implements Second Granularity.

Second specific Cron Expressions can be provided by specifying the `e` option of the `Crontab.CronExpression` Sigil.

## Example

* `~e[*/5]e` - Run Every 5 Seconds
* `~e[*/10 * */2]e` - Run Every 10 Seconds in every even hour

## Important

This PR is based on #144. After the merge of it, I'll rebase onto master again. Do not merge yet.

## Assumptions (correct me if I'm wrong!)
* Jobs without second granularity always run at second `0`.
* The notation `@every N seconds` is not needed with the sigil to specify cron expressions.