### PR TITLE
Replace 'crons' with 'cron' in configuration example.

### DIFF
--- a/lib/quantum/config.ex
+++ b/lib/quantum/config.ex
@@ -39,7 +39,7 @@ defmodule Quantum.Config do
 
     ~s"""
     config :quantum, your_app_name: [
-      crons: #{crons}
+      cron: #{crons}
     ]
     """
   end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -33,7 +33,7 @@ defmodule Quantum.ConfigTest do
 
       Example:
       config :quantum, your_app_name: [
-        crons: [1, 2, 3]
+        cron: [1, 2, 3]
       ]
       """
   end


### PR DESCRIPTION
The suggested migrated configuration tricked me into using "crons", which does nothing actually :)