### PR TITLE
Add crontab to applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Quantum.Mixfile do
   end
 
   def application do
-    [applications: [:calendar], mod: {Quantum.Application, []}]
+    [applications: [:calendar, :crontab], mod: {Quantum.Application, []}]
   end
 
   defp package do


### PR DESCRIPTION
Starting an OTP release with quantum 1.9 fails (using distillery), and gives me a warning that crontab was not included in the release. The released application fails to start, given the crontab dependency is missing.

After adding it to the applications list and releasing, the warning is no longer present, and the application can start. I verified that the one job I have is indeed being run.