### PR TITLE
Solution: Quantum.Job Structs are not correctly normalized

### DIFF
--- a/test/normalizer_test.exs
+++ b/test/normalizer_test.exs
@@ -31,6 +31,63 @@ defmodule Quantum.NormalizerTest do
     }}
   end
 
+  test "named job with old schedule" do
+    job = {:newsletter, [
+      schedule: "@weekly",
+      task: "MyModule.my_method",
+      args: [1, 2, 3],
+      overlap: false,
+      nodes: [:atom@node, "string@node"]
+    ]}
+
+    assert normalize(job) == {:newsletter, %Quantum.Job{
+      name: :newsletter,
+      schedule: ~e[@weekly],
+      task: {"MyModule", "my_method"},
+      args: [1, 2, 3],
+      overlap: false,
+      nodes: [:atom@node, :string@node]
+    }}
+  end
+
+  test "named job with struct" do
+    job = {:newsletter, %Quantum.Job{
+      schedule: ~e[@weekly],
+      task: "MyModule.my_method",
+      args: [1, 2, 3],
+      overlap: false,
+      nodes: [:atom@node, "string@node"]
+    }}
+
+    assert normalize(job) == {:newsletter, %Quantum.Job{
+      name: :newsletter,
+      schedule: ~e[@weekly],
+      task: {"MyModule", "my_method"},
+      args: [1, 2, 3],
+      overlap: false,
+      nodes: [:atom@node, :string@node]
+    }}
+  end
+
+  test "named job with struct and old schedule" do
+    job = {:newsletter, %Quantum.Job{
+      schedule: "@weekly",
+      task: "MyModule.my_method",
+      args: [1, 2, 3],
+      overlap: false,
+      nodes: [:atom@node, "string@node"]
+    }}
+
+    assert normalize(job) == {:newsletter, %Quantum.Job{
+      name: :newsletter,
+      schedule: ~e[@weekly],
+      task: {"MyModule", "my_method"},
+      args: [1, 2, 3],
+      overlap: false,
+      nodes: [:atom@node, :string@node]
+    }}
+  end
+
   test "unnamed job as string" do
     job = "* * * * * MyModule.my_method"
 


### PR DESCRIPTION
Fix for #160 

The described issue happens because a struct like `%Quantum.Job{schedule: "* * * * *", task: fn -> Logger.info("tick") end}` was not properly normalized.

Expected Normalizer Output:

```
%Quantum.Job{name: :something, pid: nil, state: :active, timezone: :utc, args: [],
             nodes: [:nonode@nohost], overlap: true, schedule: ~e[* * * * *],
             task: fn -> Logger.info("tick") end}
```

Actual Output:

```
%Quantum.Job{name: :newsletter, pid: nil, state: :active, timezone: :utc, args: [],
             nodes: [:nonode@nohost], overlap: true, schedule: "* * * * *",
             task: fn -> Logger.info("tick") end}
```

(The difference it the not normalized schedule.)

The proposed solution normalizes all values except just the `nodes` and `name`.