### PR TITLE
Solution: Less Config Notations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Configure your cronjobs in your `config/config.exs` like this:
 config :quantum, :your_app,
   cron: [
     # Every minute
-    "* * * * *":      {"Heartbeat", :send},
+    {"* * * * *",      {Heartbeat, :send, []}},
     # Every 15 minutes
-    "*/15 * * * *":   fn -> System.cmd("rm", ["/tmp/tmp_"]) end,
+    {"*/15 * * * *",   fn -> System.cmd("rm", ["/tmp/tmp_"]) end},
     # Runs on 18, 20, 22, 0, 2, 4, 6:
-    "0 18-6/2 * * *": fn -> :mnesia.backup('/var/backup/mnesia') end,
+    {"0 18-6/2 * * *", fn -> :mnesia.backup('/var/backup/mnesia') end},
     # Runs every midnight:
-    "@daily":         &Backup.backup/0
+    {"@daily",         {Backup, :backup, []}}
   ]
 ```
 

--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -34,6 +34,14 @@ defmodule Quantum do
       it being generated on multiple nodes. With the following
       configuration, Quantum will be run as a globally unique
       process across the cluster.
+
+    * `:default_schedule` - Default Schedule of new Job
+
+    * `:default_overlap` - Default Overlap of new Job
+
+    * `:default_timezone` - Default Timezone of new Job
+
+    * `:default_nodes` - Default Nodes of new Job
   """
 
   alias Quantum.Job
@@ -100,12 +108,17 @@ defmodule Quantum do
         |> add_job
       end
 
-      def new_job do
-        %Job{}
-        |> Job.set_schedule(Application.get_env(:quantum, :default_schedule, ~e[*]))
-        |> Job.set_overlap(Application.get_env(:quantum, :default_overlap, true))
-        |> Job.set_timezone(Application.get_env(:quantum, :default_timezone, :utc))
-        |> Job.set_nodes(Application.get_env(:quantum, :default_nodes, [node()]))
+      def new_job(config \\ config()) do
+        job = %Job{}
+        |> Job.set_overlap(Keyword.fetch!(config, :default_overlap))
+        |> Job.set_timezone(Keyword.fetch!(config, :default_timezone))
+        |> Job.set_nodes(Keyword.fetch!(config, :default_nodes))
+
+        if Keyword.fetch!(config, :default_schedule) do
+          Job.set_schedule(job, Keyword.fetch!(config, :default_schedule))
+        else
+          job
+        end
       end
 
       def deactivate_job(n) do

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -1,26 +1,49 @@
 defmodule Quantum.Job do
+  @moduledoc """
+  This Struct defines a Job.
 
-  @moduledoc false
+  ## Usage
 
-  @default_schedule Application.get_env(:quantum, :default_schedule, nil)
-  @default_args     Application.get_env(:quantum, :default_args, [])
-  @default_overlap  Application.get_env(:quantum, :default_overlap, true)
-  @default_timezone Application.get_env(:quantum, :timezone, :utc)
+  The struct should never be defined by hand. Use `Quantum.new_job/0` to create a new job and use the setters mentioned
+  below to mutate the job.
+
+  This is to ensure type safety.
+
+  """
+
+  alias Crontab.CronExpression
 
   defstruct [
     name: nil,
-    schedule: @default_schedule,
+    schedule: nil,
     task: nil, # {module, function}
-    args: @default_args,
     state: :active, # active/inactive
     nodes: nil,
-    overlap: @default_overlap,
+    overlap: nil,
     pid: nil,
-    timezone: @default_timezone
+    timezone: nil
   ]
 
-  @type t :: %Quantum.Job{}
+  @type t :: %__MODULE__{}
+  @type state :: :active | :inactive
+  @type task :: {atom, atom, [any]} | function
 
+  @doc """
+  Determines if a Job is executable.
+
+  ### Examples
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.set_state(:inactive)
+      ...> |> Quantum.Job.executable?
+      false
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.executable?
+      true
+
+  """
+  @spec executable?(t) :: boolean
   def executable?(job) do
     cond do
       job.state != :active    -> false # Do not execute inactive jobs
@@ -39,4 +62,139 @@ defmodule Quantum.Job do
     end
   end
 
+  @doc """
+  Sets a jobs name.
+
+  ### Parameters
+
+    1. `job` - The job struct to modify
+    2. `name` - The name to set
+
+  ### Examples
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.set_name(:name)
+      ...> |> Map.get(:name)
+      :name
+
+  """
+  @spec set_name(t, atom) :: t
+  def set_name(job = %__MODULE__{}, name) when is_atom(name), do: Map.put(job, :name, name)
+
+  @doc """
+  Sets a jobs schedule.
+
+  ### Parameters
+
+    1. `job` - The job struct to modify
+    2. `schedule` - The schedule to set. May only be of type `%Crontab.CronExpression{}`
+
+  ### Examples
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.set_schedule(Crontab.CronExpression.Parser.parse!("*/7"))
+      ...> |> Map.get(:schedule)
+      Crontab.CronExpression.Parser.parse!("*/7")
+
+  """
+  @spec set_schedule(t, CronExpression.t) :: t
+  def set_schedule(job = %__MODULE__{}, schedule = %CronExpression{}), do: Map.put(job, :schedule, schedule)
+
+  @doc """
+  Sets a jobs schedule.
+
+  ### Parameters
+
+    1. `job` - The job struct to modify
+    2. `schedule` - The schedule to set. May only be of type `%Crontab.CronExpression{}`
+
+  ### Examples
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.set_schedule(Crontab.CronExpression.Parser.parse!("*/7"))
+      ...> |> Map.get(:schedule)
+      Crontab.CronExpression.Parser.parse!("*/7")
+
+  """
+  @spec set_task(t, task) :: t
+  def set_task(job = %__MODULE__{}, task = {module, function, args})
+  when is_atom(module) and is_atom(function) and is_list(args), do: Map.put(job, :task, task)
+  def set_task(job = %__MODULE__{}, task) when is_function(task, 0), do: Map.put(job, :task, task)
+
+  @doc """
+  Sets a jobs state.
+
+  ### Parameters
+
+    1. `job` - The job struct to modify
+    2. `state` - The state to set
+
+  ### Examples
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.set_state(:active)
+      ...> |> Map.get(:state)
+      :active
+
+  """
+  @spec set_state(t, state) :: t
+  def set_state(job = %__MODULE__{}, :active), do: Map.put(job, :state, :active)
+  def set_state(job = %__MODULE__{}, :inactive), do: Map.put(job, :state, :inactive)
+
+  @doc """
+  Sets a jobs nodes to run on.
+
+  ### Parameters
+
+    1. `job` - The job struct to modify
+    2. `nodes` - The nodes to set
+
+  ### Examples
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.set_nodes([:one, :two])
+      ...> |> Map.get(:nodes)
+      [:one, :two]
+
+  """
+  @spec set_nodes(t, [node]) :: t
+  def set_nodes(job = %__MODULE__{}, nodes), do: Map.put(job, :nodes, nodes)
+
+  @doc """
+  Sets a jobs overlap.
+
+  ### Parameters
+
+    1. `job` - The job struct to modify
+    2. `overlap` - Enable / Disable Overlap
+
+  ### Examples
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.set_overlap(false)
+      ...> |> Map.get(:overlap)
+      false
+
+  """
+  @spec set_overlap(t, boolean) :: t
+  def set_overlap(job = %__MODULE__{}, overlap?) when is_boolean(overlap?), do: Map.put(job, :overlap, overlap?)
+
+  @doc """
+  Sets a jobs timezone.
+
+  ### Parameters
+
+    1. `job` - The job struct to modify
+    2. `timezone` - The timezone to set.
+
+  ### Examples
+
+      iex> Quantum.new_job()
+      ...> |> Quantum.Job.set_timezone("Europe/Zurich")
+      ...> |> Map.get(:timezone)
+      "Europe/Zurich"
+
+  """
+  @spec set_timezone(t, String.t | :utc | :local) :: t
+  def set_timezone(job = %__MODULE__{}, timezone), do: Map.put(job, :timezone, timezone)
 end

--- a/lib/quantum/scheduler.ex
+++ b/lib/quantum/scheduler.ex
@@ -75,7 +75,7 @@ defmodule Quantum.Scheduler do
     Enum.map state.jobs, fn({name, job}) ->
       if Job.executable?(job) do
         task = Task.Supervisor.async_nolink(Keyword.fetch!(state.opts, :task_supervisor), Quantum.Executor,
-            :execute, [{job.schedule, job.task, job.args, job.timezone}, state])
+            :execute, [{job.schedule, job.task, job.timezone}, state])
         {name, %{job | pid: task.pid}}
       else
         {name, job}

--- a/lib/quantum/supervisor.ex
+++ b/lib/quantum/supervisor.ex
@@ -4,6 +4,7 @@ defmodule Quantum.Supervisor do
 
   require Logger
   alias Quantum.Normalizer
+  alias Quantum.Job
 
   @defaults [global?: false, cron: [], timezone: :utc, timeout: 5_000]
 
@@ -22,10 +23,10 @@ defmodule Quantum.Supervisor do
     if config = Application.get_env(otp_app, quantum) do
       config = [otp_app: otp_app, quantum: quantum] ++
                (@defaults |> Keyword.merge(config) |> Keyword.merge(custom))
-
+               
       jobs = config
       |> Keyword.get(:jobs)
-      |> Enum.map(&Normalizer.normalize/1)
+      |> Enum.map(fn job_config -> Normalizer.normalize(quantum.new_job(), job_config) end)
       |> remove_jobs_with_duplicate_names(quantum)
 
       scheduler = if Keyword.fetch!(config, :global?),
@@ -60,13 +61,16 @@ defmodule Quantum.Supervisor do
   end
 
   defp remove_jobs_with_duplicate_names(job_list, quantum) do
-    Enum.reduce(job_list, [], fn({name, job}, acc) ->
-      if name && Enum.member?(Keyword.keys(acc), name) do
-        Logger.warn("Job with name '#{name}' of quantum '#{quantum}' not started due to duplicate job name")
-        acc
-      else
-        [{name, job} | acc]
-      end
+    Enum.reduce(job_list, [], fn
+      (job = %Job{name: nil}, acc) ->
+        [{nil, job} | acc]
+      (job = %Job{name: name}, acc) ->
+        if Enum.member?(Keyword.keys(acc), name) do
+          Logger.warn("Job '#{name}' not started due to duplicate job name")
+          acc
+        else
+          [{name, job} | acc]
+        end
     end)
   end
 

--- a/pages/runtime.md
+++ b/pages/runtime.md
@@ -3,13 +3,25 @@
 If you want to add jobs on runtime, this is possible too:
 
 ```elixir
+# Short Form
 Quantum.add_job("1 * * * *", fn -> :ok end)
+
+# Explicit Form
+Quantum.new_job()
+|> Quantum.Job.set_schedule(~e[1 * * * *])
+|> Quantum.Job.set_task(fn -> :ok end)
 ```
 
 Add a named job at runtime:
 
 ```elixir
-job = %Quantum.Job{schedule: "* * * * *", task: fn -> IO.puts "tick" end}
+import Crontab.CronExpression
+
+Quantum.new_job()
+|> Quantum.Job.set_name(:ticker)
+|> Quantum.Job.set_schedule(~e[1 * * * *])
+|> Quantum.Job.set_task(fn -> :ok end)
+
 Quantum.add_job(:ticker, job)
 ```
 
@@ -46,6 +58,10 @@ The following example will put a tick into the `stdout` every second.
 ```elixir
 import Crontab.CronExpression
 
-job = %Quantum.Job{schedule: ~e[* * * * *], task: fn -> IO.puts "tick" end}
-Quantum.add_job(:ticker, job)
+Quantum.new_job()
+|> Quantum.Job.set_name(:ticker)
+|> Quantum.Job.set_schedule(~e[1 * * * *]e)
+|> Quantum.Job.set_task(fn -> IO.puts "tick" end)
+
+Quantum.add_job(job)
 ```

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -30,90 +30,89 @@ defmodule Quantum.ExecutorTest do
   end
 
   test "check minutely" do
-    assert execute({~e[* * * * *], &ok/0, [], @default_timezone}, @default_date) == :ok
+    assert execute({~e[* * * * *], &ok/0, @default_timezone}, @default_date) == :ok
   end
 
   test "check hourly" do
-    assert execute({~e[0 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[0 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, s: 0, w: 1}) == false
-    assert execute({~e[@hourly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[@hourly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, s: 0, w: 1}) == false
+    assert execute({~e[0 * * * *], &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[0 * * * *], &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, s: 0, w: 1}) == false
+    assert execute({~e[@hourly],   &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@hourly],   &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 1, s: 0, w: 1}) == false
   end
 
   test "check daily" do
-    assert execute({~e[0 0 * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[0 0 * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
-    assert execute({~e[@daily],    &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[@daily],    &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
-    assert execute({~e[@midnight], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[@midnight], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
+    assert execute({~e[0 0 * * *], &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[0 0 * * *], &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
+    assert execute({~e[@daily],    &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@daily],    &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
+    assert execute({~e[@midnight], &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@midnight], &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 0, m: 1, s: 0, w: 1}) == false
   end
 
   test "check weekly" do
-    assert execute({~e[0 0 * * 0], &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
-    assert execute({~e[0 0 * * 0], &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, s: 0, w: 0}) == false
-    assert execute({~e[@weekly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
-    assert execute({~e[@weekly],   &ok/0, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[0 0 * * 0], &ok/0, @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[0 0 * * 0], &ok/0, @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[@weekly],   &ok/0, @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@weekly],   &ok/0, @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 1, s: 0, w: 0}) == false
   end
 
   test "check monthly" do
-    assert execute({~e[0 0 1 * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
-    assert execute({~e[0 0 1 * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, s: 0, w: 0}) == false
-    assert execute({~e[@monthly],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
-    assert execute({~e[@monthly],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[0 0 1 * *], &ok/0, @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[0 0 1 * *], &ok/0, @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[@monthly],  &ok/0, @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@monthly],  &ok/0, @default_timezone}, %{d: {2015, 12, 1}, h: 0, m: 1, s: 0, w: 0}) == false
   end
 
   test "check yearly" do
-    assert execute({~e[0 0 1 1 *], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
-    assert execute({~e[0 0 1 1 *], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
-    assert execute({~e[@annually], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
-    assert execute({~e[@annually], &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
-    assert execute({~e[@yearly],   &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
-    assert execute({~e[@yearly],   &ok/0, [], @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[0 0 1 1 *], &ok/0, @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[0 0 1 1 *], &ok/0, @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[@annually], &ok/0, @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@annually], &ok/0, @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
+    assert execute({~e[@yearly],   &ok/0, @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@yearly],   &ok/0, @default_timezone}, %{d: {2016, 1, 1}, h: 0, m: 1, s: 0, w: 0}) == false
   end
 
   test "parse */5" do
-    assert execute({~e[*/5 * * * *], &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[*/5 * * * *], &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1}) == :ok
   end
 
   test "parse 5" do
-    assert execute({~e[5 * * * *],  &ok/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 5, s: 0, w: 1}) == :ok
+    assert execute({~e[5 * * * *],  &ok/0, @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 5, s: 0, w: 1}) == :ok
   end
 
   test "counter example" do
-    execute({~e[5 * * * *], &flunk/0, [], @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1})
+    execute({~e[5 * * * *], &flunk/0, @default_timezone}, %{d: {2015, 12, 31}, h: 12, m: 0, s: 0, w: 1})
   end
 
   test "function as tuple" do
-    assert execute({~e[* * * * *], {__MODULE__, :ok}, [], @default_timezone}, @default_date) == :ok
-    assert execute({~e[* * * * *], {"Quantum.ExecutorTest", "ok"}, [], @default_timezone}, @default_date) == :ok
+    assert execute({~e[* * * * *], {__MODULE__, :ok, []}, @default_timezone}, @default_date) == :ok
   end
 
   test "readable schedule" do
-    assert execute({~e[@weekly], {__MODULE__, :ok}, [], @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
+    assert execute({~e[@weekly], {__MODULE__, :ok, []}, @default_timezone}, %{d: {2015, 12, 27}, h: 0, m: 0, s: 0, w: 0}) == :ok
   end
 
   test "function with args" do
-    assert execute({~e[* * * * *], &ret/1, [:passed], @default_timezone}, @default_date) == :passed
+    assert execute({~e[* * * * *], &ok/0, @default_timezone}, @default_date) == :ok
   end
 
   test "reboot" do
-    assert execute({~e[@reboot], &ok/0, [], @default_timezone}, %{r: 1}) == :ok
-    assert execute({~e[@reboot], &ok/0, [], @default_timezone}, %{r: 0}) == false
+    assert execute({~e[@reboot], &ok/0, @default_timezone}, %{r: 1}) == :ok
+    assert execute({~e[@reboot], &ok/0, @default_timezone}, %{r: 0}) == false
   end
 
   @tag timezone: "local"
   test "Raise if trying to use 'local' timezone" do
-    assert assert_raise(RuntimeError, fn -> execute({~e[@daily], &ok/0, [], :local}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) end)
+    assert assert_raise(RuntimeError, fn -> execute({~e[@daily], &ok/0, :local}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) end)
   end
 
   @tag timezone: "CET"
   test "accepts custom timezones" do
-    assert execute({~e[@daily], &ok/0, [], "Etc/GMT+1"}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@daily], &ok/0, "Etc/GMT+1"}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
   end
 
   @tag timezone: "America/Chicago"
   test "accepts custom timezones(America/Chicago)" do
-    assert execute({~e[@daily], &ok/0, [], "America/Chicago"}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@daily], &ok/0, "America/Chicago"}, %{d: {2015, 12, 31}, h: 0, m: 0, s: 0, w: 1}) == :ok
   end
 end

--- a/test/normalizer_test.exs
+++ b/test/normalizer_test.exs
@@ -4,136 +4,120 @@ defmodule Quantum.NormalizerTest do
   import Quantum.Normalizer
   import Crontab.CronExpression
 
-  # test "normalize" do
-  #   assert normalize({"0", nil}) == {"0", nil}
-  #   assert normalize({"A", nil}) == {"a", nil}
-  #   assert normalize({"jan", nil}) == {"1", nil}
-  #   assert normalize({:atom, nil}) == {"atom", nil}
-  #   assert normalize("* * * * * MyApp.MyModule.my_method") == {"* * * * *", {"MyApp.MyModule", :my_method}}
-  # end
+  alias Quantum.Job
+
+  defmodule Runner do
+    use Quantum, otp_app: :quantum_test
+  end
+
+  defp start_runner(name) do
+    {:ok, _pid} = name.start_link()
+    on_exit fn ->
+      case Process.whereis(Quantum.Supervisor) do
+        nil ->
+          :ok
+        pid ->
+          name.stop(pid)
+      end
+    end
+  end
+
+  setup do
+    Application.put_env(:quantum_test, Quantum.NormalizerTest.Runner, jobs: [])
+
+    start_runner(Quantum.NormalizerTest.Runner)
+  end
 
   test "named job" do
     job = {:newsletter, [
       schedule: ~e[@weekly],
-      task: "MyModule.my_method",
-      args: [1, 2, 3],
+      task: {MyModule, :my_method, [1, 2, 3]},
       overlap: false,
       nodes: [:atom@node, "string@node"]
     ]}
 
-    assert normalize(job) == {:newsletter, %Quantum.Job{
-      name: :newsletter,
-      schedule: ~e[@weekly],
-      task: {"MyModule", "my_method"},
-      args: [1, 2, 3],
+    expected_job = Quantum.NormalizerTest.Runner.new_job()
+    |> Job.set_name(:newsletter)
+    |> Job.set_schedule(~e[@weekly])
+    |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
+    |> Job.set_overlap(false)
+    |> Job.set_nodes([:atom@node, :string@node])
+
+    assert normalize(Quantum.NormalizerTest.Runner.new_job(), job) == expected_job
+  end
+
+  test "expression tuple extended" do
+    job = {:newsletter, [
+      schedule: {:extended, "*"},
+      task: {MyModule, :my_method, [1, 2, 3]},
       overlap: false,
-      nodes: [:atom@node, :string@node]
-    }}
+      nodes: [:atom@node, "string@node"]
+    ]}
+
+    expected_job = Quantum.NormalizerTest.Runner.new_job()
+    |> Job.set_name(:newsletter)
+    |> Job.set_schedule(~e[*]e)
+    |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
+    |> Job.set_overlap(false)
+    |> Job.set_nodes([:atom@node, :string@node])
+
+    assert normalize(Quantum.NormalizerTest.Runner.new_job(), job) == expected_job
+  end
+
+  test "expression tuple not extended" do
+    job = {:newsletter, [
+      schedule: {:cron, "*"},
+      task: {MyModule, :my_method, [1, 2, 3]},
+      overlap: false,
+      nodes: [:atom@node, "string@node"]
+    ]}
+
+    expected_job = Quantum.NormalizerTest.Runner.new_job()
+    |> Job.set_name(:newsletter)
+    |> Job.set_schedule(~e[*])
+    |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
+    |> Job.set_overlap(false)
+    |> Job.set_nodes([:atom@node, :string@node])
+
+    assert normalize(Quantum.NormalizerTest.Runner.new_job(), job) == expected_job
   end
 
   test "named job with old schedule" do
     job = {:newsletter, [
       schedule: "@weekly",
-      task: "MyModule.my_method",
-      args: [1, 2, 3],
+      task: {MyModule, :my_method, [1, 2, 3]},
       overlap: false,
       nodes: [:atom@node, "string@node"]
     ]}
 
-    assert normalize(job) == {:newsletter, %Quantum.Job{
-      name: :newsletter,
-      schedule: ~e[@weekly],
-      task: {"MyModule", "my_method"},
-      args: [1, 2, 3],
-      overlap: false,
-      nodes: [:atom@node, :string@node]
-    }}
-  end
+    expected_job = Quantum.NormalizerTest.Runner.new_job()
+    |> Job.set_name(:newsletter)
+    |> Job.set_schedule(~e[@weekly])
+    |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
+    |> Job.set_overlap(false)
+    |> Job.set_nodes([:atom@node, :string@node])
 
-  test "named job with struct" do
-    job = {:newsletter, %Quantum.Job{
-      schedule: ~e[@weekly],
-      task: "MyModule.my_method",
-      args: [1, 2, 3],
-      overlap: false,
-      nodes: [:atom@node, "string@node"]
-    }}
-
-    assert normalize(job) == {:newsletter, %Quantum.Job{
-      name: :newsletter,
-      schedule: ~e[@weekly],
-      task: {"MyModule", "my_method"},
-      args: [1, 2, 3],
-      overlap: false,
-      nodes: [:atom@node, :string@node]
-    }}
-  end
-
-  test "named job with struct and old schedule" do
-    job = {:newsletter, %Quantum.Job{
-      schedule: "@weekly",
-      task: "MyModule.my_method",
-      args: [1, 2, 3],
-      overlap: false,
-      nodes: [:atom@node, "string@node"]
-    }}
-
-    assert normalize(job) == {:newsletter, %Quantum.Job{
-      name: :newsletter,
-      schedule: ~e[@weekly],
-      task: {"MyModule", "my_method"},
-      args: [1, 2, 3],
-      overlap: false,
-      nodes: [:atom@node, :string@node]
-    }}
-  end
-
-  test "unnamed job as string" do
-    job = "* * * * * MyModule.my_method"
-
-    assert normalize(job) == {nil, %Quantum.Job{
-      name: nil,
-      schedule: ~e[* * * * *],
-      task: {"MyModule", "my_method"},
-      args: [],
-      nodes: default_nodes()
-    }}
+    assert normalize(Quantum.NormalizerTest.Runner.new_job(), job) == expected_job
   end
 
   test "unnamed job as tuple" do
-    job = {~e[* * * * *], "MyModule.my_method"}
+    job = {~e[* * * * *], {MyModule, :my_method, [1, 2, 3]}}
 
-    assert normalize(job) == {nil, %Quantum.Job{
-      name: nil,
-      schedule: ~e[* * * * *],
-      task: {"MyModule", "my_method"},
-      args: [],
-      nodes: default_nodes()
-    }}
+    expected_job = Quantum.NormalizerTest.Runner.new_job()
+    |> Job.set_schedule(~e[* * * * *])
+    |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
+
+    assert normalize(Quantum.NormalizerTest.Runner.new_job(), job) == expected_job
   end
 
   test "unnamed job as tuple with arguments" do
-    job = {"* * * * *", {"MyModule", "my_method", [1, 2, 3]}}
+    job = {"* * * * *", {MyModule, :my_method, [1, 2, 3]}}
 
-    assert normalize(job) == {nil, %Quantum.Job{
-      name: nil,
-      schedule: ~e[* * * * *],
-      task: {"MyModule", "my_method"},
-      args: [1, 2, 3],
-      nodes: default_nodes()
-    }}
-  end
+    expected_job = Quantum.NormalizerTest.Runner.new_job()
+    |> Job.set_schedule(~e[* * * * *])
+    |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
 
-  test "cron-like unnamed job" do
-    job = "@weekly MyModule.my_method"
-
-    assert normalize(job) == {nil, %Quantum.Job{
-      name: nil,
-      schedule: ~e[@weekly],
-      task: {"MyModule", "my_method"},
-      args: [],
-      nodes: default_nodes()
-    }}
+    assert normalize(Quantum.NormalizerTest.Runner.new_job(), job) == expected_job
   end
 
 end

--- a/test/quantum/job_test.exs
+++ b/test/quantum/job_test.exs
@@ -1,0 +1,3 @@
+defmodule Quantum.JobTest do
+  use ExUnit.Case, async: true
+end

--- a/test/quantum_startup_test.exs
+++ b/test/quantum_startup_test.exs
@@ -13,10 +13,10 @@ defmodule QuantumStartupTest do
       end
 
       test_jobs =
-        [test_job: [schedule: ~e[1 * * * *], task: fn -> :ok end],
-         test_job: [schedule: ~e[2 * * * *], task: fn -> :ok end],
-         "3 * * * *": fn -> :ok end,
-         "4 * * * *": fn -> :ok end]
+        [{:test_job, [schedule: ~e[1 * * * *], task: fn -> :ok end]},
+         {:test_job, [schedule: ~e[2 * * * *], task: fn -> :ok end]},
+         {"3 * * * *", fn -> :ok end},
+         {"4 * * * *", fn -> :ok end}]
 
       Application.put_env(:quantum_test, QuantumStartupTest.Runner, jobs: test_jobs)
 

--- a/test/quantum_startup_test.exs
+++ b/test/quantum_startup_test.exs
@@ -9,7 +9,7 @@ defmodule QuantumStartupTest do
   test "prevent duplicate job names on startup" do
     capture_log(fn ->
       defmodule Runner do
-        use Quantum, otp_app: :quantum_test
+        use Quantum, otp_app: :quantum_startup_test
       end
 
       test_jobs =
@@ -18,7 +18,7 @@ defmodule QuantumStartupTest do
          {"3 * * * *", fn -> :ok end},
          {"4 * * * *", fn -> :ok end}]
 
-      Application.put_env(:quantum_test, QuantumStartupTest.Runner, jobs: test_jobs)
+      Application.put_env(:quantum_startup_test, QuantumStartupTest.Runner, jobs: test_jobs)
 
       {:ok, _pid} = QuantumStartupTest.Runner.start_link()
 

--- a/test/quantum_test.exs
+++ b/test/quantum_test.exs
@@ -37,7 +37,7 @@ defmodule QuantumTest do
     test "returns Quantum.Job struct" do
       %Quantum.Job{schedule: schedule, overlap: overlap, timezone: timezone} = QuantumTest.Runner.new_job()
 
-      assert schedule == ~e[*]
+      assert schedule == nil
       assert overlap == true
       assert timezone == :utc
     end
@@ -46,9 +46,12 @@ defmodule QuantumTest do
       default_schedule = ~e[*/7]
       default_overlap = false
       default_timezone = "Europe/Zurich"
-      Application.put_env(:quantum, :default_schedule, default_schedule)
-      Application.put_env(:quantum, :default_overlap, default_overlap)
-      Application.put_env(:quantum, :default_timezone, default_timezone)
+      Application.put_env(:quantum_test, QuantumTest.Runner, [
+        jobs: [],
+        default_schedule: default_schedule,
+        default_overlap: default_overlap,
+        default_timezone: default_timezone
+      ])
 
       %Quantum.Job{schedule: schedule, overlap: overlap, timezone: timezone} = QuantumTest.Runner.new_job()
 
@@ -415,8 +418,6 @@ defmodule QuantumTest do
   end
 
   test "timeout can be configured for genserver correctly" do
-    Application.put_env(:quantum, :timeout, 0)
-
     job = QuantumTest.ZeroTimeoutRunner.new_job()
     |> Job.set_name(:tmpjob)
     |> Job.set_schedule(~e[* */5 * * *])

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -9,19 +9,19 @@ defmodule Quantum.TimezoneTest do
 
   test "check timezones" do
     # We choose timezones with no daylight savings time or other weird things going on, so that these tests can pass at all times
-    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+2"}, %{d: {2015, 12, 15}, h: 23, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+3"}, %{d: {2015, 12, 16}, h: 0, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[0 21 15 * *], &ok/0, [], "Etc/GMT+3"}, %{d: {2015, 12, 15}, h: 0, m: 0, s: 0, w: 1}) == false
+    assert execute({~e[0 21 15 * *], &ok/0, "Etc/GMT+2"}, %{d: {2015, 12, 15}, h: 23, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[0 21 15 * *], &ok/0, "Etc/GMT+3"}, %{d: {2015, 12, 16}, h: 0, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[0 21 15 * *], &ok/0, "Etc/GMT+3"}, %{d: {2015, 12, 15}, h: 0, m: 0, s: 0, w: 1}) == false
   end
 
   test "check timezone with weekly" do
-    assert execute({~e[@weekly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 5}, h: 21, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[@weekly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 6}, h: 0, m: 0, s: 0, w: 1}) == false
+    assert execute({~e[@weekly], &ok/0, "Etc/GMT-3"}, %{d: {2016, 3, 5}, h: 21, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@weekly], &ok/0, "Etc/GMT-3"}, %{d: {2016, 3, 6}, h: 0, m: 0, s: 0, w: 1}) == false
   end
 
   test "check timezone with monthly" do
-    assert execute({~e[@monthly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 2, 29}, h: 21, m: 0, s: 0, w: 1}) == :ok
-    assert execute({~e[@monthly], &ok/0, [], "Etc/GMT-3"}, %{d: {2016, 3, 1}, h: 0, m: 0, s: 0, w: 1}) == false
+    assert execute({~e[@monthly], &ok/0, "Etc/GMT-3"}, %{d: {2016, 2, 29}, h: 21, m: 0, s: 0, w: 1}) == :ok
+    assert execute({~e[@monthly], &ok/0, "Etc/GMT-3"}, %{d: {2016, 3, 1}, h: 0, m: 0, s: 0, w: 1}) == false
   end
 
 end


### PR DESCRIPTION
Implementation of #174 

This PR cleans up the config notations.

The `args` property of the `Quantum.Job` is now embedded in the `task`.

This is a huge BC break (although it is easy to fix). It can not be released until the other big BC breaks are done too. (for example #152)

This is not yet thoroughly tested.