### PR TITLE
PID can be remote ID. Do not throw error when checking if alive process

### DIFF
--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -27,8 +27,15 @@ defmodule Quantum.Job do
       not node() in job.nodes -> false # Job shall not run on this node
       job.overlap == true     -> true  # Job may overlap
       job.pid == nil          -> true  # Job has not been started
-      Process.alive?(job.pid) -> false # Previous job is still running
+      !is_alive?(job.pid)     -> false # Previous job is still running
       true                    -> true  # Previous job has finished
+    end
+  end
+
+  defp is_alive?(pid) do
+    case :rpc.pinfo(pid)  do
+      :undefined -> false
+      _ -> true
     end
   end
 

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -33,7 +33,7 @@ defmodule Quantum.Job do
   end
 
   defp is_alive?(pid) do
-    case :rpc.pinfo(pid)  do
+    case :rpc.pinfo(pid) do
       :undefined -> false
       _ -> true
     end

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -27,7 +27,7 @@ defmodule Quantum.Job do
       not node() in job.nodes -> false # Job shall not run on this node
       job.overlap == true     -> true  # Job may overlap
       job.pid == nil          -> true  # Job has not been started
-      !is_alive?(job.pid)     -> false # Previous job is still running
+      is_alive?(job.pid)     -> false # Previous job is still running
       true                    -> true  # Previous job has finished
     end
   end

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -27,7 +27,7 @@ defmodule Quantum.Job do
       not node() in job.nodes -> false # Job shall not run on this node
       job.overlap == true     -> true  # Job may overlap
       job.pid == nil          -> true  # Job has not been started
-      is_alive?(job.pid)     -> false # Previous job is still running
+      is_alive?(job.pid)      -> false # Previous job is still running
       true                    -> true  # Previous job has finished
     end
   end


### PR DESCRIPTION
I had a scenario, where I shut down quantum in current node and transfer all jobs to other. When running the jobs from the other node, even though the PIDs are now global ones, :erlang.is_process_alive works only with local nodes.

Let me know if you think this might help others.