### PR TITLE
Solution: Implement Run Strategies

### DIFF
--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -9,14 +9,13 @@ defmodule Quantum.Normalizer do
   @fields [:name,
            :schedule,
            :task,
-           :overlap,
-           :nodes]
+           :overlap]
 
   @type config_short_notation :: {config_schedule, config_task}
   # TODO: remove any and fix dialyzer
   @type config_full_notation :: {config_name | nil, Keyword.t | struct | any}
 
-  @typep field :: :name | :schedule | :task | :overlap | :nodes
+  @typep field :: :name | :schedule | :task | :overlap
   @type config_schedule :: Crontab.CronExpression.t | String.t | {:cron, String.t} | {:extended, String.t}
   @type config_task :: {module, fun, [any]} | (() -> any)
   @type config_name :: String.t | atom
@@ -76,13 +75,6 @@ defmodule Quantum.Normalizer do
     normalize_options(job, options, tail)
   end
 
-  defp normalize_options(job, options = %{nodes: nodes}, [:nodes | tail]) do
-    normalize_options(Job.set_nodes(job, normalize_nodes(nodes)), options, tail)
-  end
-  defp normalize_options(job, options, [:nodes | tail]) do
-    normalize_options(job, options, tail)
-  end
-
   defp normalize_options(job, _, []), do: job
 
   @spec normalize_task(config_task) :: Job.task
@@ -95,13 +87,6 @@ defmodule Quantum.Normalizer do
   defp normalize_schedule(e) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!
   defp normalize_schedule({:cron, e}) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!
   defp normalize_schedule({:extended, e}) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!(true)
-
-  @spec normalize_nodes([Node.t | String.t]) :: Job.nodes
-  defp normalize_nodes(list) when is_list(list), do: Enum.map(list, &normalize_node/1)
-
-  @spec normalize_node(atom | String.t) :: Node.t
-  defp normalize_node(node) when is_binary(node), do: String.to_atom(node)
-  defp normalize_node(node) when is_atom(node), do: node
 
   @spec normalize_name(atom | String.t) :: atom
   defp normalize_name(name) when is_binary(name), do: String.to_atom(name)

--- a/lib/quantum/run_strategy.ex
+++ b/lib/quantum/run_strategy.ex
@@ -1,0 +1,10 @@
+defprotocol Quantum.RunStrategy do
+  @moduledoc """
+  Strategy to run Jobs over nodes
+  """
+
+  @doc """
+  Get nodes to run on
+  """
+  def nodes(strategy, job)
+end

--- a/lib/quantum/run_strategy/all.ex
+++ b/lib/quantum/run_strategy/all.ex
@@ -1,0 +1,20 @@
+defmodule Quantum.RunStrategy.All do
+  @moduledoc """
+  Run job on all node of the node list
+
+  If the node list is `:cluster`, all nodes of the cluster will be used.
+  """
+
+  @type t :: %__MODULE__{nodes: [Node.t | :cluster]}
+
+  defstruct [nodes: nil]
+
+  defimpl Quantum.RunStrategy do
+    def nodes(%Quantum.RunStrategy.All{nodes: :cluster}, _) do
+      [node() | Node.list]
+    end
+    def nodes(%Quantum.RunStrategy.All{nodes: nodes}, _) do
+      nodes
+    end
+  end
+end

--- a/lib/quantum/run_strategy/random.ex
+++ b/lib/quantum/run_strategy/random.ex
@@ -1,0 +1,48 @@
+defmodule Quantum.RunStrategy.Random do
+  @moduledoc """
+  Run job on one node of the list randomly.
+
+  If the node list is `:cluster`, one node of the cluster will be used.
+
+  This run strategy also makes sure, that the node doesn't run in two places at the same time
+  if `job.overlap` is falsy.
+  """
+
+  @type t :: %__MODULE__{nodes: [Node.t] | :cluster}
+
+  defstruct [nodes: nil]
+
+  defimpl Quantum.RunStrategy do
+    alias Quantum.Job
+
+    def nodes(%Quantum.RunStrategy.Random{nodes: :cluster}, job) do
+      if job_pending?(job) do
+        []
+      else
+        [node() | Node.list]
+        |> Enum.shuffle
+        |> Enum.take(1)
+      end
+    end
+    def nodes(%Quantum.RunStrategy.Random{nodes: nodes}, job) do
+      if job_pending?(job) do
+        []
+      else
+        nodes
+        |> Enum.shuffle
+        |> Enum.take(1)
+      end
+    end
+
+    defp job_pending?(%Job{overlap: false, pids: pids}) do
+      count = pids
+      |> Enum.reject(fn({_, pid}) -> pid == nil end)
+      |> Enum.filter(fn({_, pid}) -> Job.is_alive?(pid) end)
+      |> Enum.count
+      count > 0
+    end
+    defp job_pending?(%Job{overlap: true}) do
+      false
+    end
+  end
+end

--- a/lib/quantum/scheduler.ex
+++ b/lib/quantum/scheduler.ex
@@ -92,7 +92,7 @@ defmodule Quantum.Scheduler do
         job = %Job{}
         |> Job.set_overlap(Keyword.fetch!(config, :default_overlap))
         |> Job.set_timezone(Keyword.fetch!(config, :default_timezone))
-        |> Job.set_nodes(Keyword.fetch!(config, :default_nodes))
+        |> Job.set_run_strategy(Keyword.fetch!(config, :default_run_strategy))
 
         if Keyword.fetch!(config, :default_schedule) do
           Job.set_schedule(job, Keyword.fetch!(config, :default_schedule))

--- a/lib/quantum/supervisor.ex
+++ b/lib/quantum/supervisor.ex
@@ -7,6 +7,7 @@ defmodule Quantum.Supervisor do
 
   alias Quantum.Normalizer
   alias Quantum.Job
+  alias Quantum.RunStrategy.Random
 
   @defaults [global?: false,
              cron: [],
@@ -14,7 +15,7 @@ defmodule Quantum.Supervisor do
              default_schedule: nil,
              default_overlap: true,
              default_timezone: :utc,
-             default_nodes: [node()]]
+             default_run_strategy: %Random{nodes: :cluster}]
 
   @doc """
   Starts the quantum supervisor.

--- a/test/quantum/normalizer_test.exs
+++ b/test/quantum/normalizer_test.exs
@@ -33,7 +33,6 @@ defmodule Quantum.NormalizerTest do
       schedule: ~e[@weekly],
       task: {MyModule, :my_method, [1, 2, 3]},
       overlap: false,
-      nodes: [:atom@node, "string@node"]
     ]}
 
     expected_job = Quantum.NormalizerTest.Scheduler.new_job()
@@ -41,7 +40,6 @@ defmodule Quantum.NormalizerTest do
     |> Job.set_schedule(~e[@weekly])
     |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
     |> Job.set_overlap(false)
-    |> Job.set_nodes([:atom@node, :string@node])
 
     assert normalize(Quantum.NormalizerTest.Scheduler.new_job(), job) == expected_job
   end
@@ -51,7 +49,6 @@ defmodule Quantum.NormalizerTest do
       schedule: {:extended, "*"},
       task: {MyModule, :my_method, [1, 2, 3]},
       overlap: false,
-      nodes: [:atom@node, "string@node"]
     ]}
 
     expected_job = Quantum.NormalizerTest.Scheduler.new_job()
@@ -59,7 +56,6 @@ defmodule Quantum.NormalizerTest do
     |> Job.set_schedule(~e[*]e)
     |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
     |> Job.set_overlap(false)
-    |> Job.set_nodes([:atom@node, :string@node])
 
     assert normalize(Quantum.NormalizerTest.Scheduler.new_job(), job) == expected_job
   end
@@ -69,7 +65,6 @@ defmodule Quantum.NormalizerTest do
       schedule: {:cron, "*"},
       task: {MyModule, :my_method, [1, 2, 3]},
       overlap: false,
-      nodes: [:atom@node, "string@node"]
     ]}
 
     expected_job = Quantum.NormalizerTest.Scheduler.new_job()
@@ -77,7 +72,6 @@ defmodule Quantum.NormalizerTest do
     |> Job.set_schedule(~e[*])
     |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
     |> Job.set_overlap(false)
-    |> Job.set_nodes([:atom@node, :string@node])
 
     assert normalize(Quantum.NormalizerTest.Scheduler.new_job(), job) == expected_job
   end
@@ -87,7 +81,6 @@ defmodule Quantum.NormalizerTest do
       schedule: "@weekly",
       task: {MyModule, :my_method, [1, 2, 3]},
       overlap: false,
-      nodes: [:atom@node, "string@node"]
     ]}
 
     expected_job = Quantum.NormalizerTest.Scheduler.new_job()
@@ -95,7 +88,6 @@ defmodule Quantum.NormalizerTest do
     |> Job.set_schedule(~e[@weekly])
     |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
     |> Job.set_overlap(false)
-    |> Job.set_nodes([:atom@node, :string@node])
 
     assert normalize(Quantum.NormalizerTest.Scheduler.new_job(), job) == expected_job
   end


### PR DESCRIPTION
Implementation of #180 

I had another idea on how to solve the issue. It should be extendable very easy.

Instead of `job.nodes` there is `job.run_strategy` (Protocol: `Quantum.RunStrategy`).

There are currently two run strategies supported:

* `Quantum.RunStrategy.All` - Run job on all nodes of list / in cluster.
* `Quantum.RunStrategy.Random` - Run job on a random node of list / in cluster.

It is possible to write custom strategies by implementing the `Quantum.RunStrategy` protocol.

The code is currently not tested & documented. I just want to hear what you think about it.

If the idea is accepted, I'll have to do proper testing & documentation before merge.

Open Question:

* What can be configured via Mix Config? What Notation?