### PR TITLE
Solution: Minor fixes for documetation

### DIFF
--- a/MIGRATE-V2.md
+++ b/MIGRATE-V2.md
@@ -54,8 +54,8 @@ The configuration notations have been cleaned up. Those are the existing notatio
 
 ```elixir
 config :quantum, :your_app,
-  cron: [
-    # Named Explicit Form
+  jobs: [
+    # Named Keyword Explicit Form
    [name: NAME, schedule: CONFIG_SCHEDULE_NOTATION, task: CONFIG_TASK_NOTATION, OTHER_FIELDS],
 
     # Unnamed Explicit Form

--- a/MIGRATE-V2.md
+++ b/MIGRATE-V2.md
@@ -53,13 +53,17 @@ The configuration notations have been cleaned up. Those are the existing notatio
 ### Configuration Syntax
 
 ```elixir
-config :quantum, :your_app,
+config :your_app, YourApp.Scheduler,
   jobs: [
+    # Named Tuple Explicit Form
+   {NAME, [schedule: CONFIG_SCHEDULE_NOTATION, task: CONFIG_TASK_NOTATION, OTHER_FIELDS]},
+
     # Named Keyword Explicit Form
    [name: NAME, schedule: CONFIG_SCHEDULE_NOTATION, task: CONFIG_TASK_NOTATION, OTHER_FIELDS],
 
     # Unnamed Explicit Form
    [schedule: CONFIG_SCHEDULE_NOTATION, task: CONFIG_TASK_NOTATION, OTHER_FIELDS],
+
     # Short Form
    {CONFIG_SCHEDULE_NOTATION, CONFIG_TASK_NOTATION},
   ]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Configure your cronjobs in your `config/config.exs` like this:
 
 ```elixir
 config :your_app, YourApp.Scheduler,
-  cron: [
+  jobs: [
     # Every minute
     {"* * * * *",      {Heartbeat, :send, []}},
     # Every 15 minutes

--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -31,7 +31,9 @@ defmodule Quantum.Normalizer do
 
   """
   @spec normalize(Job.t, config_full_notation | config_short_notation) :: Quantum.Job.t
-  def normalize(base, job)
+  def normalize(base, job) when is_list(job) do
+    normalize(base, {Keyword.get(job, :name), job})
+  end
   def normalize(base, {job_name, opts}) when is_list(opts) do
     opts = opts
     |> Enum.reduce(%{}, fn {key, value}, acc -> Map.put(acc, key, value) end)

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -4,7 +4,7 @@ Configure your cronjobs in your `config/config.exs` like this:
 
 ```elixir
 config :your_app, YourApp.Scheduler,
-  cron: [
+  jobs: [
     # Every minute
     {"* * * * *",              {Heartbeat, :send, []}},
     {{:cron, "* * * * *"},     {Heartbeat, :send, []}},
@@ -36,7 +36,7 @@ You can define named jobs in your config like this:
 
 ```elixir
 config :your_app, YourApp.Scheduler,
-  cron: [
+  jobs: [
     news_letter: [
       schedule: "@weekly",
       task: {Heartbeat, :send, [:arg1]},
@@ -65,7 +65,7 @@ config :your_app, YourApp.Scheduler,
   default_schedule: "* * * * *",
   default_overlap: false,
   default_timezone: :utc,
-  cron: [
+  jobs: [
     # Your cronjobs
   ]
 ```
@@ -81,7 +81,7 @@ With Sigil:
 import Crontab.CronExpression
 
 config :your_app, YourApp.Scheduler,
-  cron: [
+  jobs: [
     news_letter: [
       schedule: {"*/2", true}, # Runs every two seconds
       task: {Heartbeat, :send, [:arg1]}
@@ -121,7 +121,7 @@ as a globally unique process across the cluster.
 ```elixir
 config :your_app, YourApp.Scheduler,
   global?: true,
-  cron: [
+  jobs: [
     # Your cronjobs
   ]
 ```
@@ -135,7 +135,7 @@ To specify another default timezone, add the following `default_timezone` option
 ```elixir
 config :your_app, YourApp.Scheduler,
   default_timezone: "America/Chicago",
-  cron: [
+  jobs: [
     # Your cronjobs
   ]
 ```

--- a/test/quantum/normalizer_test.exs
+++ b/test/quantum/normalizer_test.exs
@@ -124,4 +124,27 @@ defmodule Quantum.NormalizerTest do
     assert normalize(Quantum.NormalizerTest.Scheduler.new_job(), job) == expected_job
   end
 
+  test "named job as a keyword" do
+    job = [name: :newsletter, schedule: "@weekly", task: {MyModule, :my_method, [1, 2, 3]}, overlap: false]
+
+    expected_job = Quantum.NormalizerTest.Scheduler.new_job()
+    |> Job.set_name(:newsletter)
+    |> Job.set_schedule(~e[@weekly])
+    |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
+    |> Job.set_overlap(false)
+
+    assert normalize(Quantum.NormalizerTest.Scheduler.new_job(), job) == expected_job
+  end
+
+  test "unnamed job as a keyword" do
+    job = [schedule: "@weekly", task: {MyModule, :my_method, [1, 2, 3]}, overlap: false]
+
+    expected_job = Quantum.NormalizerTest.Scheduler.new_job()
+    |> Job.set_schedule(~e[@weekly])
+    |> Job.set_task({MyModule, :my_method, [1, 2, 3]})
+    |> Job.set_overlap(false)
+
+    assert normalize(Quantum.NormalizerTest.Scheduler.new_job(), job) == expected_job
+  end
+
 end


### PR DESCRIPTION
Also, I took the liberty of adding the implementation for keyword job notation mentioned in `MIGRATE-V2.md`.