### PR TITLE
Solution: Fix link migration-v2.html -> migrate-v2.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-The whole library has been refactored. See the [Migration Guide](https://hexdocs.pm/quantum/migration-v2.html).
+The whole library has been refactored. See the [Migration Guide](https://hexdocs.pm/quantum/migrate-v2.html).
 
 ## 1.9.1 - 2017-03-17
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ end
 
 ## Migrate to V2
 
-See the [Migration Guide](https://hexdocs.pm/quantum/migration-v2.html).
+See the [Migration Guide](https://hexdocs.pm/quantum/migrate-v2.html).
 
 ## Usage
 


### PR DESCRIPTION
* This doc page is generated from [MIGRATE-V2.md](https://github.com/c-rack/quantum-elixir/blob/ae534b/MIGRATE-V2.md)