### PR TITLE
Allow all schedule formats for default schedule

### DIFF
--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -92,11 +92,12 @@ defmodule Quantum.Normalizer do
   defp normalize_task(fun) when is_function(fun, 0), do: fun
   defp normalize_task(fun) when is_function(fun), do: raise "Only 0 arity functions are supported via the short syntax."
 
+  @doc false
   @spec normalize_schedule(config_schedule) :: Job.schedule
-  defp normalize_schedule(e = %Crontab.CronExpression{}), do: e
-  defp normalize_schedule(e) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!
-  defp normalize_schedule({:cron, e}) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!
-  defp normalize_schedule({:extended, e}) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!(true)
+  def normalize_schedule(e = %Crontab.CronExpression{}), do: e
+  def normalize_schedule(e) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!
+  def normalize_schedule({:cron, e}) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!
+  def normalize_schedule({:extended, e}) when is_binary(e), do: e |> String.downcase |> CronExpressionParser.parse!(true)
 
   @spec normalize_name(atom | String.t) :: atom
   defp normalize_name(name) when is_binary(name), do: String.to_atom(name)

--- a/lib/quantum/scheduler.ex
+++ b/lib/quantum/scheduler.ex
@@ -98,8 +98,9 @@ defmodule Quantum.Scheduler do
         |> Job.set_timezone(Keyword.fetch!(config, :default_timezone))
         |> Job.set_run_strategy(run_strategy)
 
-        if Keyword.fetch!(config, :default_schedule) do
-          Job.set_schedule(job, Keyword.fetch!(config, :default_schedule))
+        default_schedule = Keyword.fetch!(config, :default_schedule)
+        if default_schedule do
+          Job.set_schedule(job, Quantum.Normalizer.normalize_schedule(default_schedule))
         else
           job
         end

--- a/test/quantum_test.exs
+++ b/test/quantum_test.exs
@@ -50,7 +50,7 @@ defmodule QuantumTest do
     end
 
     test "has defaults set" do
-      default_schedule = ~e[*/7]
+      default_schedule = "*/7"
       default_overlap = false
       default_timezone = "Europe/Zurich"
       Application.put_env(:quantum_test, QuantumTest.Scheduler, [
@@ -62,7 +62,7 @@ defmodule QuantumTest do
 
       %Quantum.Job{schedule: schedule, overlap: overlap, timezone: timezone} = QuantumTest.Scheduler.new_job()
 
-      assert schedule == default_schedule
+      assert schedule == ~e[#{default_schedule}]
       assert overlap == default_overlap
       assert timezone == default_timezone
     end


### PR DESCRIPTION
[Override default settings](https://github.com/c-rack/quantum-elixir/blob/b49e291/pages/configuration.md#override-default-settings) shows `default_schedule` can be set with a string, but it only works with a `Crontab.CronExpression` struct. This will normalize the schedule, allowing any of the schedule formats.