### PR TITLE
Solution: Ensure Calendar.DateTime is compiled instead of Calendar

### DIFF
--- a/lib/quantum/date_library/calendar.ex
+++ b/lib/quantum/date_library/calendar.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Calendar) do
+if Code.ensure_compiled?(Calendar.DateTime) do
   defmodule Quantum.DateLibrary.Calendar do
     @moduledoc """
     `calendar` implementation of `Quantum.DateLibrary`.


### PR DESCRIPTION
Fixes the following warning, observed on Elixir 1.4.4 when using the Timex rather than the Calendar dependency:
```
warning: function Calendar.DateTime.shift_zone!/2 is undefined (module Calendar.DateTime is not available)
  lib/quantum/date_library/calendar.ex:35
```

The module `Calendar` is defined by Elixir itself, so the conditional always evaluated to true. The hex package Calendar defines the module in use here, `Calendar.DateTime`.