### PR TITLE
Solution: simplify test setup and eliminate race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 sudo: false
 elixir:
-  - 1.4.0
   - 1.4.5
+  - 1.5.0-rc.0
 otp_release:
   - 18.3
   - 19.3
@@ -12,7 +12,3 @@ after_success:
 after_script:
   - MIX_ENV=docs mix deps.get
   - MIX_ENV=docs mix inch.report
-matrix:
-  exclude:
-    - elixir: 1.4.0
-      otp_release: 20.0

--- a/test/quantum/normalizer_test.exs
+++ b/test/quantum/normalizer_test.exs
@@ -11,18 +11,10 @@ defmodule Quantum.NormalizerTest do
   end
 
   setup_all do
-    Application.put_env(:quantum_test, Quantum.NormalizerTest.Scheduler, jobs: [])
+    Application.put_env(:quantum_test, Scheduler, jobs: [])
 
-    {:ok, _pid} = Quantum.NormalizerTest.Scheduler.start_link()
-
-    on_exit fn ->
-      case Process.whereis(Quantum.Supervisor) do
-        nil ->
-          :ok
-        pid ->
-          Quantum.NormalizerTest.Scheduler.stop(pid)
-      end
-    end
+    {:ok, _pid} = Scheduler.start_link()
+    :ok
   end
 
   test "named job" do

--- a/test/quantum/normalizer_test.exs
+++ b/test/quantum/normalizer_test.exs
@@ -10,22 +10,19 @@ defmodule Quantum.NormalizerTest do
     use Quantum.Scheduler, otp_app: :quantum_test
   end
 
-  defp start_scheduler(name) do
-    {:ok, _pid} = name.start_link()
+  setup_all do
+    Application.put_env(:quantum_test, Quantum.NormalizerTest.Scheduler, jobs: [])
+
+    {:ok, _pid} = Quantum.NormalizerTest.Scheduler.start_link()
+
     on_exit fn ->
       case Process.whereis(Quantum.Supervisor) do
         nil ->
           :ok
         pid ->
-          name.stop(pid)
+          Quantum.NormalizerTest.Scheduler.stop(pid)
       end
     end
-  end
-
-  setup do
-    Application.put_env(:quantum_test, Quantum.NormalizerTest.Scheduler, jobs: [])
-
-    start_scheduler(Quantum.NormalizerTest.Scheduler)
   end
 
   test "named job" do

--- a/test/quantum_test.exs
+++ b/test/quantum_test.exs
@@ -23,6 +23,7 @@ defmodule QuantumTest do
 
   defp start_scheduler(name) do
     {:ok, pid} = name.start_link()
+
     on_exit fn ->
       capture_log(fn ->
         if Process.alive?(pid) do
@@ -33,10 +34,10 @@ defmodule QuantumTest do
   end
 
   setup do
-    Application.put_env(:quantum_test, QuantumTest.Scheduler, jobs: [])
+    Application.put_env(:quantum_test, Scheduler, jobs: [])
     Application.put_env(:quantum_test, ZeroTimeoutScheduler, timeout: 0, jobs: [])
 
-    start_scheduler(QuantumTest.Scheduler)
+    start_scheduler(Scheduler)
     start_scheduler(ZeroTimeoutScheduler)
   end
 


### PR DESCRIPTION
Fix #204 

I ran master `mix test` 50 times in a loop and managed to reproduce the CI build error 4 times.
With this fix, I ran the loop again for 100 times and saw no failures.

Some notes regarding the current code structure:
- Feels weird that the scheduler starts the supervisor, not the other way around
- Runner and Executor probably can use some module docs, their names are so confusing
- Data transformations (i.e. new job) could probably be separated from the code that belongs to running processes, hence you don't have to start up anything just to test configuration normalization
- More separation could be used to isolate spawning processes, where some don't require the others in order to work