### PR TITLE
Solution: Mix Application Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,7 @@ defp deps do
 end
 ```
 
-**2. and the list of applications. You can skip this step if you are using
-Elixir 1.4 or later:**
-```elixir
-def application do
-  [applications: [:quantum, :other_apps...]]
-end
-```
-
-**3. and create a scheduler for your app:**
+**2. and create a scheduler for your app:**
 ```elixir
 defmodule YourApp.Scheduler do
   use Quantum.Scheduler,
@@ -40,7 +32,7 @@ defmodule YourApp.Scheduler do
 end
 ```
 
-**4. and your application's supervision tree:**
+**3. and your application's supervision tree:**
 ```elixir
 defmodule YourApp.Application do
   use Application

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ end
 Elixir 1.4 or later:**
 ```elixir
 def application do
-  [applications: [:quantum, :timex, :other_apps...]]
+  [applications: [:quantum, :other_apps...]]
 end
 ```
 

--- a/lib/quantum/application.ex
+++ b/lib/quantum/application.ex
@@ -3,18 +3,16 @@ defmodule Quantum.Application do
 
   use Application
 
-  @dependency_application Application.get_env(:quantum, :date_library, Quantum.DateLibrary.Timex)
-    .dependency_application()
+  @deps Application.get_env(:quantum, :date_library, Quantum.DateLibrary.Timex)
 
-  case @dependency_application do
-    nil ->
-      def start(_type, _args) do
-        {:ok, self()}
-      end
-    _ ->
-      def start(_type, _args) do
-        Application.ensure_all_started(@dependency_application, :permanent)
-        {:ok, self()}
-      end
+  if @deps do
+    def start(_type, _args) do
+      Application.ensure_all_started(@deps, :permanent)
+      {:ok, self()}
+    end
+  else
+    def start(_type, _args) do
+      {:ok, self()}
+    end
   end
 end

--- a/lib/quantum/application.ex
+++ b/lib/quantum/application.ex
@@ -6,14 +6,15 @@ defmodule Quantum.Application do
   @dependency_application Application.get_env(:quantum, :date_library, Quantum.DateLibrary.Timex)
     .dependency_application()
 
-  def start(_type, _args) do
-    start_dependencies(@dependency_application)
-
-    {:ok, self()}
+  case @dependency_application do
+    nil ->
+      def start(_type, _args) do
+        {:ok, self()}
+      end
+    _ ->
+      def start(_type, _args) do
+        Application.ensure_all_started(@dependency_application, :permanent)
+        {:ok, self()}
+      end
   end
-
-  defp start_dependencies(nil),
-    do: nil
-  defp start_dependencies(application) when is_atom(application),
-    do: Application.ensure_all_started(application, :permanent)
 end

--- a/lib/quantum/application.ex
+++ b/lib/quantum/application.ex
@@ -1,0 +1,19 @@
+defmodule Quantum.Application do
+  @moduledoc false
+
+  use Application
+
+  @dependency_application Application.get_env(:quantum, :date_library, Quantum.DateLibrary.Timex)
+    .dependency_application()
+
+  def start(_type, _args) do
+    start_dependencies(@dependency_application)
+
+    {:ok, self()}
+  end
+
+  defp start_dependencies(nil),
+    do: nil
+  defp start_dependencies(application) when is_atom(application),
+    do: Application.ensure_all_started(application, :permanent)
+end

--- a/lib/quantum/date_library.ex
+++ b/lib/quantum/date_library.ex
@@ -18,5 +18,5 @@ defmodule Quantum.DateLibrary do
   @doc """
   Gives back the required application dependency to start, if any is needed.
   """
-  @callback dependency_application :: :atom | nil
+  @callback dependency_application :: atom | nil
 end

--- a/lib/quantum/date_library.ex
+++ b/lib/quantum/date_library.ex
@@ -14,4 +14,9 @@ defmodule Quantum.DateLibrary do
   Convert `NaiveDateTime` in UTC to `NaiveDateTime` in given tz.
   """
   @callback utc_to_tz(NaiveDateTime.t, String.t) :: NaiveDateTime.t | no_return
+
+  @doc """
+  Gives back the required application dependency to start, if any is needed.
+  """
+  @callback dependency_application :: :atom | nil
 end

--- a/lib/quantum/date_library/calendar.ex
+++ b/lib/quantum/date_library/calendar.ex
@@ -14,10 +14,6 @@ if Code.ensure_compiled?(Calendar.DateTime) do
 
       `mix.exs`
 
-        def application do
-          [applications: [:quantum, :calendar]]
-        end
-
         defp deps do
           [{:quantum, "*"},
            {:calendar, "*"}]
@@ -35,5 +31,8 @@ if Code.ensure_compiled?(Calendar.DateTime) do
       |> CalendarDateTime.shift_zone!(tz)
       |> DateTime.to_naive
     end
+
+    @spec dependency_application :: :calendar
+    def dependency_application, do: :calendar
   end
 end

--- a/lib/quantum/date_library/timex.ex
+++ b/lib/quantum/date_library/timex.ex
@@ -14,10 +14,6 @@ if Code.ensure_compiled?(Timex) do
 
       `mix.exs`
 
-        def application do
-          [applications: [:quantum, :timex]]
-        end
-
         defp deps do
           [{:quantum, "*"},
            {:timex, "*"}]
@@ -35,5 +31,8 @@ if Code.ensure_compiled?(Timex) do
       |> Timezone.convert(tz)
       |> DateTime.to_naive
     end
+
+    @spec dependency_application :: :timex
+    def dependency_application, do: :timex
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,11 +23,12 @@ defmodule Quantum.Mixfile do
   end
 
   def application do
-    case Mix.env do
-      :test -> [applications: [:crontab, :timex]]
-      _ -> [applications: [:crontab]]
-    end
+    [mod: {Quantum.Application, []},
+     extra_applications: extra_applications(Mix.env)]
   end
+
+  defp extra_applications(:test), do: [:logger, :timex]
+  defp extra_applications(_), do: [:logger]
 
   defp package do
     %{
@@ -73,12 +74,12 @@ defmodule Quantum.Mixfile do
       {:timex,       "~> 3.1.13", optional: true},
       {:calendar,    "~> 0.17", optional: true},
       {:crontab,     "~> 1.1"},
-      {:earmark,     "~> 1.0",  only: [:dev, :docs]},
-      {:ex_doc,      "~> 0.13", only: [:dev, :docs]},
-      {:excoveralls, "~> 0.5",  only: [:dev, :test]},
-      {:inch_ex,     "~> 0.5",  only: [:dev, :docs]},
+      {:earmark,     "~> 1.0",  only: [:dev, :docs], runtime: false},
+      {:ex_doc,      "~> 0.13", only: [:dev, :docs], runtime: false},
+      {:excoveralls, "~> 0.5",  only: [:dev, :test], runtime: false},
+      {:inch_ex,     "~> 0.5",  only: [:dev, :docs], runtime: false},
       {:dialyxir,    "~> 0.5",  only: [:dev], runtime: false},
-      {:credo,       "~> 0.7",  only: [:dev, :test]}
+      {:credo,       "~> 0.7",  only: [:dev, :test], runtime: false}
     ]
   end
 end


### PR DESCRIPTION
* Use Elixir 1.4 Way to configure App Dependencies
* Change README to only mention the Elixir 1.4 Apps Configuration (1.3 is no longer supported)
* Mark many deps to not be in runtime
* Start Date Lib automatically (will hopefully prevent many user support requests)