### PR TITLE
add date-key to state of Runner before running jobs

### DIFF
--- a/lib/quantum/runner.ex
+++ b/lib/quantum/runner.ex
@@ -24,9 +24,8 @@ defmodule Quantum.Runner do
   end
 
   def init(state) do
-    new_state = state
-    |> Map.put(:jobs, run(state))
-    |> Map.put(:date, Timer.tick())
+    new_state = Map.put(state, :date, Timer.tick())
+    new_state = Map.put(state, :jobs, run(new_state))
 
     {:ok, new_state}
   end


### PR DESCRIPTION
This pull-request fixes #233. 

The function Quantum.Executor.execute_task_if_date_matches/2 requires the key :date to be present in the state parameter. So the date-variable has to be added before the initial execution of jobs in the function Quantum.Runner.init/1.