### PR TITLE
add supervisor for hot upgrade

### DIFF
--- a/lib/quantum/application.ex
+++ b/lib/quantum/application.ex
@@ -10,11 +10,15 @@ defmodule Quantum.Application do
   if @deps do
     def start(_type, _args) do
       Application.ensure_all_started(@deps, :permanent)
-      {:ok, self()}
+      children = []
+      opts = [strategy: :one_for_one, name: Quantum.Supervisor]
+      Supervisor.start_link(children, opts)
     end
   else
     def start(_type, _args) do
-      {:ok, self()}
+      children = []
+      opts = [strategy: :one_for_one, name: Quantum.Supervisor]
+      Supervisor.start_link(children, opts)
     end
   end
 end


### PR DESCRIPTION
hmmmmm, thanks first for the repo. 

but, after I upgraded to v2, I met the trouble when I using hot upgrade, just like:

```
iex(i_can_not_tell_you@i_can_not_tell_you)3> :release_handler.install_release('0.0.2', [{:update_paths, true}]) 

<0.7606.0>: reason: {'EXIT',{timeout,{sys,get_status,[<0.7606.0>]}}}

10:01:27.534 [error] release_handler: cannot find top supervisor for application :quantum

release_handler:install_release(Vsn="0.0.2" Opts=[{update_paths,true}]) failed, Reason={'EXIT',
                                                                                         {timeout,
                                                                                          {sys,
                                                                                           get_status,
                                                                                           [<0.7606.0>]}}}
```

just because here:

https://github.com/erlang/otp/blob/OTP-20.1/lib/sasl/src/release_handler_1.erl#L579-L607

Plz review. Thanks again.