### PR TITLE
Solution: Add Local Run Strategy

### DIFF
--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -51,8 +51,12 @@ defmodule Quantum.Job do
   """
   @spec new(config :: Keyword.t()) :: t
   def new(config) do
-    with {run_strategy_name, options} <- Keyword.fetch!(config, :run_strategy),
-         run_strategy <- run_strategy_name.normalize_config!(options),
+    {run_strategy_name, options} =
+      case Keyword.fetch!(config, :run_strategy) do
+        {module, option} -> {module, option}
+        module -> {module, nil}
+      end
+    with run_strategy <- run_strategy_name.normalize_config!(options),
          name <- make_ref(),
          overlap when is_boolean(overlap) <- Keyword.fetch!(config, :overlap),
          timezone when timezone == :utc or is_binary(timezone) <-

--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -107,7 +107,10 @@ defmodule Quantum.Normalizer do
   defp normalize_name(name) when is_binary(name), do: String.to_atom(name)
   defp normalize_name(name) when is_atom(name), do: name
 
-  @spec normalize_run_strategy({module, any}) :: NodeList
+  @spec normalize_run_strategy({module, any} | module) :: NodeList
+  defp normalize_run_strategy(strategy) when is_atom(strategy) do
+    strategy.normalize_config!(nil)
+  end
   defp normalize_run_strategy({strategy, options}) when is_atom(strategy) do
     strategy.normalize_config!(options)
   end

--- a/lib/quantum/run_strategy/local.ex
+++ b/lib/quantum/run_strategy/local.ex
@@ -1,0 +1,32 @@
+defmodule Quantum.RunStrategy.Local do
+  @moduledoc """
+  Run job on local node
+
+  ### Mix Configuration
+
+      config :my_app, MyApp.Scheduler,
+        jobs: [
+          # Run on local node
+          [schedule: "* * * * *", run_strategy: Quantum.RunStrategy.Local]
+        ]
+
+  """
+
+  @type t :: %__MODULE__{nodes: any}
+
+  defstruct nodes: nil
+
+  @behaviour Quantum.RunStrategy
+
+  alias Quantum.Job
+
+  @spec normalize_config!(any) :: t
+  def normalize_config!(_), do: %__MODULE__{}
+
+  defimpl Quantum.RunStrategy.NodeList do
+    @spec nodes(any, Job.t()) :: [Node.t()]
+    def nodes(_, _) do
+      [node()]
+    end
+  end
+end

--- a/pages/run-strategies.md
+++ b/pages/run-strategies.md
@@ -18,7 +18,10 @@ config :my_app, MyApp.Scheduler,
 The run strategy can be configured by providing a tuple of the strategy module name and it's options. If you choose `Local Node` strategy, the config should be:
 
 ```elixir
-[schedule: "* * * * *", run_strategy: Quantum.RunStrategy.Local],
+config :my_app, MyApp.Scheduler,
+  jobs: [
+    [schedule: "* * * * *", run_strategy: Quantum.RunStrategy.Local],
+  ]
 ```
 
 ### Runtime

--- a/pages/run-strategies.md
+++ b/pages/run-strategies.md
@@ -15,7 +15,11 @@ config :my_app, MyApp.Scheduler,
   ]
 ```
 
-The run strategy can be configured by providing a tuple of the strategy module name and it's options.
+The run strategy can be configured by providing a tuple of the strategy module name and it's options. If you choose `Local Node` strategy, the config should be:
+
+```elixir
+[schedule: "* * * * *", run_strategy: Quantum.RunStrategy.Local],
+```
 
 ### Runtime
 
@@ -34,6 +38,12 @@ If you want to run a task on all nodes of either a list or in the whole cluster,
 `Quantum.RunStrategy.Random`
 
 If you want to run a task on any node of either a list or in the whole cluster, use this strategy.
+
+### Local Node
+
+`Quantum.RunStrategy.Local`
+
+If you want to run a task on local node, use this strategy.
 
 ## Custom Run Strategy
 

--- a/test/quantum/run_strategy_test.exs
+++ b/test/quantum/run_strategy_test.exs
@@ -1,0 +1,31 @@
+defmodule Quantum.RunStrategyTest do
+  use ExUnit.Case, async: true
+
+  alias Quantum.Job
+  alias Quantum.RunStrategy.NodeList
+
+  defmodule Scheduler do
+    @moduledoc false
+
+    use Quantum.Scheduler, otp_app: :quantum_test
+  end
+
+  test "run strategy local" do
+    job = Scheduler.config(run_strategy: Quantum.RunStrategy.Local) |> Job.new()
+    assert %Job{} = job
+    assert [_] = NodeList.nodes(job.run_strategy, job)
+  end
+
+  test "run strategy random" do
+    job =
+      Scheduler.config(run_strategy: {Quantum.RunStrategy.Random, [:node1, :node2]}) |> Job.new()
+
+    assert [node] = NodeList.nodes(job.run_strategy, job)
+    assert Enum.member?([:node1, :node2], node)
+  end
+
+  test "run strategy all" do
+    job = Scheduler.config(run_strategy: {Quantum.RunStrategy.All, [:node1, :node2]}) |> Job.new()
+    assert [_, _] = NodeList.nodes(job.run_strategy, job)
+  end
+end

--- a/test/quantum/run_strategy_test.exs
+++ b/test/quantum/run_strategy_test.exs
@@ -13,19 +13,19 @@ defmodule Quantum.RunStrategyTest do
   test "run strategy local" do
     job = Job.new(Scheduler.config(run_strategy: Quantum.RunStrategy.Local))
     assert %Job{} = job
-    assert [_] = NodeList.nodes(job.run_strategy, job)
+    assert [:nonode@nohost] == NodeList.nodes(job.run_strategy, job)
   end
 
   test "run strategy random" do
     node_list = [:node1, :node2]
     job = Job.new(Scheduler.config(run_strategy: {Quantum.RunStrategy.Random, node_list}))
     assert [node] = NodeList.nodes(job.run_strategy, job)
-    assert Enum.member?([:node1, :node2], node)
+    assert Enum.member?(node_list, node)
   end
 
   test "run strategy all" do
     node_list = [:node1, :node2]
     job = Job.new(Scheduler.config(run_strategy: {Quantum.RunStrategy.All, node_list}))
-    assert [_, _] = NodeList.nodes(job.run_strategy, job)
+    assert [:node1, :node2] == NodeList.nodes(job.run_strategy, job)
   end
 end

--- a/test/quantum/run_strategy_test.exs
+++ b/test/quantum/run_strategy_test.exs
@@ -11,21 +11,21 @@ defmodule Quantum.RunStrategyTest do
   end
 
   test "run strategy local" do
-    job = Scheduler.config(run_strategy: Quantum.RunStrategy.Local) |> Job.new()
+    job = Job.new(Scheduler.config(run_strategy: Quantum.RunStrategy.Local))
     assert %Job{} = job
     assert [_] = NodeList.nodes(job.run_strategy, job)
   end
 
   test "run strategy random" do
-    job =
-      Scheduler.config(run_strategy: {Quantum.RunStrategy.Random, [:node1, :node2]}) |> Job.new()
-
+    node_list = [:node1, :node2]
+    job = Job.new(Scheduler.config(run_strategy: {Quantum.RunStrategy.Random, node_list}))
     assert [node] = NodeList.nodes(job.run_strategy, job)
     assert Enum.member?([:node1, :node2], node)
   end
 
   test "run strategy all" do
-    job = Scheduler.config(run_strategy: {Quantum.RunStrategy.All, [:node1, :node2]}) |> Job.new()
+    node_list = [:node1, :node2]
+    job = Job.new(Scheduler.config(run_strategy: {Quantum.RunStrategy.All, node_list}))
     assert [_, _] = NodeList.nodes(job.run_strategy, job)
   end
 end

--- a/test/quantum/run_strategy_test.exs
+++ b/test/quantum/run_strategy_test.exs
@@ -13,7 +13,7 @@ defmodule Quantum.RunStrategyTest do
   test "run strategy local" do
     job = Job.new(Scheduler.config(run_strategy: Quantum.RunStrategy.Local))
     assert %Job{} = job
-    assert [:nonode@nohost] == NodeList.nodes(job.run_strategy, job)
+    assert [Node.self()] == NodeList.nodes(job.run_strategy, job)
   end
 
   test "run strategy random" do


### PR DESCRIPTION
Local run strategy is used for run task on local node,

```elixir
run_strategy: {Quantum.RunStrategy.All, [node()]}
```

<del>could get the same effect, but</del> Local strategy is more intuitive.

And I add the test case for run strategy. plz !