### PR TITLE
Solution: Omit gen_stage warning

### DIFF
--- a/lib/quantum/executor_supervisor.ex
+++ b/lib/quantum/executor_supervisor.ex
@@ -18,12 +18,24 @@ defmodule Quantum.ExecutorSupervisor do
     |> Util.start_or_link()
   end
 
-  def init({execution_broadcaster, task_supervisor, task_registry}) do
-    ConsumerSupervisor.init(
-      {Quantum.Executor, {task_supervisor, task_registry}},
-      strategy: :one_for_one,
-      subscribe_to: [{execution_broadcaster, max_demand: 50}]
-    )
+  # credo:disable-for-next-line Credo.Check.Design.TagTODO
+  # TODO: Remove when gen_stage:0.12 support is dropped
+  if Util.gen_stage_v12?() do
+    def init({execution_broadcaster, task_supervisor, task_registry}) do
+      ConsumerSupervisor.init(
+        {Quantum.Executor, {task_supervisor, task_registry}},
+        strategy: :one_for_one,
+        subscribe_to: [{execution_broadcaster, max_demand: 50}]
+      )
+    end
+  else
+    def init({execution_broadcaster, task_supervisor, task_registry}) do
+      ConsumerSupervisor.init(
+        [{Quantum.Executor, {task_supervisor, task_registry}}],
+        strategy: :one_for_one,
+        subscribe_to: [{execution_broadcaster, max_demand: 50}]
+      )
+    end
   end
 
   @doc false

--- a/lib/quantum/util.ex
+++ b/lib/quantum/util.ex
@@ -15,4 +15,18 @@ defmodule Quantum.Util do
   def start_or_link(other) do
     other
   end
+
+  # credo:disable-for-next-line Credo.Check.Design.TagTODO
+  # TODO: Remove when gen_stage:0.12 support is dropped
+  def gen_stage_v12? do
+    Application.load(:gen_stage)
+
+    Application.loaded_applications()
+    |> Enum.find_value(nil, fn
+      {:gen_stage, _, version} -> version
+      _ -> false
+    end)
+    |> to_string
+    |> Version.match?("< 0.13.0")
+  end
 end


### PR DESCRIPTION
This seems to generate confusion since we got the same report twice in 24 hours. I don't really like to have code like this in our codebase. What do you think @c-rack?

Is there a way to do this at compile time?